### PR TITLE
Can now specify recipient by tx hash and recover public key

### DIFF
--- a/umbra-js/README.md
+++ b/umbra-js/README.md
@@ -43,6 +43,21 @@ console.log(stealthFromPublic.address === stealthFromPrivate.address); // true
 console.log('Private key to access received funds: ', stealthFromPrivate.privateKeyHex);
 ```
 
+Note that a `KeyPair` instance can be created from a public key, private key, or
+transaction hash.
+
+- For private keys, enter the full 66 character key as shown above.
+- For public keys, enter the full 132 character key as shown above.
+- For transaction hashes, we must specify that we are passing a transaction hash. Also note
+that the instance is returned asynchronously as we must first recover the public key from
+the transaction data. Use the syntax below to create a `KeyPair` instances from a transaction hash.
+
+```javascript
+// Create KeyPair instance from tx hash
+const txHash = '0x123.....';
+const recipientFromTxHash = await new KeyPair(txHash, true);
+```
+
 ## Development
 
 1. Run `npm install`

--- a/umbra-js/README.md
+++ b/umbra-js/README.md
@@ -48,14 +48,15 @@ transaction hash.
 
 - For private keys, enter the full 66 character key as shown above.
 - For public keys, enter the full 132 character key as shown above.
-- For transaction hashes, we must specify that we are passing a transaction hash. Also note
-that the instance is returned asynchronously as we must first recover the public key from
-the transaction data. Use the syntax below to create a `KeyPair` instances from a transaction hash.
+- For transaction hashes, instead of using the `new` keyword we call a static
+asynchronous method on the `KeyPair` class, which is necessary because
+we must first recover the public key from the transaction data. Use the syntax
+below to create a `KeyPair` instances from a transaction hash.
 
 ```javascript
 // Create KeyPair instance from tx hash
 const txHash = '0x123.....';
-const recipientFromTxHash = await new KeyPair(txHash, true);
+const recipientFromTxHash = await KeyPair.instanceFromTransaction(txHash);
 ```
 
 ## Development

--- a/umbra-js/test/KeyPair.test.js
+++ b/umbra-js/test/KeyPair.test.js
@@ -17,8 +17,10 @@ describe('KeyPair class', () => {
   });
 
   it('initializes an instance with valid private key', () => {
+    // Check against ganache account
     const keyPair = new KeyPair(privateKey);
     expect(keyPair.address).to.equal(address);
+    // Check against random wallet
     const keyPair2 = new KeyPair(wallet.privateKey);
     expect(keyPair2.address).to.equal(wallet.address);
   });
@@ -28,6 +30,33 @@ describe('KeyPair class', () => {
     expect(keyPair.address).to.equal(wallet.address);
   });
 
+  it('initializes an instance from a regular transaction', async () => {
+    // Specify mainnet transaction hash and its sender
+    const txHash = '0x397d8e85b0e78ed48676fdc4cd7c2f5ce55b4844eb087fde532428b0db0bd2cf';
+    const from = '0x1f973B233f5Ebb1E5D7CFe51B9aE4A32415A3A08';
+    // Create instance and check result
+    const keyPair = await new KeyPair(txHash, true);
+    expect(keyPair.address).to.equal(from);
+  });
+
+  it('initializes an instance from a contract interaction transaction', async () => {
+    // Specify mainnet transaction hash and its sender
+    const txHash = '0xed8df05af867112b6ce09df9388632605c42e5af765e61f3b808e9f7662390ee';
+    const from = '0xdc693f2e2192DB72fd92d9F589C904c4f4e6ef56';
+    // Create instance and check result
+    const keyPair = await new KeyPair(txHash, true);
+    expect(keyPair.address).to.equal(from);
+  });
+
+  it('initializes an instance from a contract creation transaction', async () => {
+    // Specify mainnet transaction hash and its sender
+    const txHash = '0x282a980bf2d7500233e4f2c55981e64826938cfe871060bfad9b22842adcb2c8';
+    const from = '0x9862D074e33003726fA05c74F0142995f33A3250';
+    // Create instance and check result
+    const keyPair = await new KeyPair(txHash, true);
+    expect(keyPair.address).to.equal(from);
+  });
+
   it('should not initialize an instance without the 0x prefix', () => {
     expect(() => new KeyPair(privateKey.slice(2)))
       .to.throw('Key must be in hex format with 0x prefix');
@@ -35,7 +64,7 @@ describe('KeyPair class', () => {
       .to.throw('Key must be in hex format with 0x prefix');
   });
 
-  it('properly derives public key parameters with both constructor methods', () => {
+  it('properly derives public key parameters with both key-based constructor methods', () => {
     const keyPair1 = new KeyPair(wallet.privateKey);
     const keyPair2 = new KeyPair(wallet.publicKey);
 

--- a/umbra-js/test/KeyPair.test.js
+++ b/umbra-js/test/KeyPair.test.js
@@ -35,7 +35,7 @@ describe('KeyPair class', () => {
     const txHash = '0x397d8e85b0e78ed48676fdc4cd7c2f5ce55b4844eb087fde532428b0db0bd2cf';
     const from = '0x1f973B233f5Ebb1E5D7CFe51B9aE4A32415A3A08';
     // Create instance and check result
-    const keyPair = await new KeyPair(txHash, true);
+    const keyPair = await KeyPair.instanceFromTransaction(txHash);
     expect(keyPair.address).to.equal(from);
   });
 
@@ -44,7 +44,7 @@ describe('KeyPair class', () => {
     const txHash = '0xed8df05af867112b6ce09df9388632605c42e5af765e61f3b808e9f7662390ee';
     const from = '0xdc693f2e2192DB72fd92d9F589C904c4f4e6ef56';
     // Create instance and check result
-    const keyPair = await new KeyPair(txHash, true);
+    const keyPair = await KeyPair.instanceFromTransaction(txHash);
     expect(keyPair.address).to.equal(from);
   });
 
@@ -53,8 +53,17 @@ describe('KeyPair class', () => {
     const txHash = '0x282a980bf2d7500233e4f2c55981e64826938cfe871060bfad9b22842adcb2c8';
     const from = '0x9862D074e33003726fA05c74F0142995f33A3250';
     // Create instance and check result
-    const keyPair = await new KeyPair(txHash, true);
+    const keyPair = await KeyPair.instanceFromTransaction(txHash);
     expect(keyPair.address).to.equal(from);
+  });
+
+  it('will recover the private key from an arbitrary transaction', async () => {
+    // Specify mainnet transaction hash and its sender
+    const txHash = '0x282a980bf2d7500233e4f2c55981e64826938cfe871060bfad9b22842adcb2c8';
+    const sendersPublicKey = '0x04ef3718f57c441836d3adf7920b041c30b1394e00fd9be3eae0a3b5ff71709d6b93cc818a889a5ea1b9742d577b603e0d7a87feb9da4d49f0260d73f72af91dd9';
+    // Create instance and check result
+    const recoveredPublicKey = await KeyPair.recoverPublicKeyFromTransaction(txHash);
+    expect(recoveredPublicKey).to.equal(sendersPublicKey);
   });
 
   it('should not initialize an instance without the 0x prefix', () => {


### PR DESCRIPTION
Add support for specifying recipient / generating `KeyPair` instance by providing a transaction hash. The public key of the sender of the specified transaction is recovered and used to instantiate the `KeyPair` instance.