### PR TITLE
Add encryption to umbra-js

### DIFF
--- a/umbra-js/classes/KeyPair.js
+++ b/umbra-js/classes/KeyPair.js
@@ -8,7 +8,7 @@ const { keccak256 } = require('js-sha3');
 const ethers = require('ethers');
 const {
   hexStringToBuffer,
-  pad32ByteHex,
+  padHex,
   recoverPublicKeyFromTransaction,
 } = require('../utils/utils');
 
@@ -40,8 +40,8 @@ class KeyPair {
 
       // Save off public key as hex, other forms computed as getters
       const publicKeyHexCoords = {
-        x: pad32ByteHex(publicKey.getX().toString('hex')),
-        y: pad32ByteHex(publicKey.getY().toString('hex')),
+        x: padHex(publicKey.getX().toString('hex')),
+        y: padHex(publicKey.getY().toString('hex')),
       };
       this.publicKeyHex = `0x04${publicKeyHexCoords.x}${publicKeyHexCoords.y}`;
     } else if (key.length === 132) {
@@ -59,8 +59,8 @@ class KeyPair {
    */
   get publicKeyHexCoords() {
     return {
-      x: pad32ByteHex(this.publicKeyHexSlim.slice(0, 64)),
-      y: pad32ByteHex(this.publicKeyHexSlim.slice(64)),
+      x: padHex(this.publicKeyHexSlim.slice(0, 64)),
+      y: padHex(this.publicKeyHexSlim.slice(64)),
     };
   }
 
@@ -157,8 +157,8 @@ class KeyPair {
     // Perform multiplication
     const publicKey = this.publicKeyEC.getPublic().mul(value.asHexSlim);
     // Get x,y hex strings
-    const x = pad32ByteHex(publicKey.getX().toString('hex'));
-    const y = pad32ByteHex(publicKey.getY().toString('hex'));
+    const x = padHex(publicKey.getX().toString('hex'));
+    const y = padHex(publicKey.getY().toString('hex'));
     // Instantiate and return new instance
     return new KeyPair(`0x04${x}${y}`);
   }
@@ -175,7 +175,7 @@ class KeyPair {
     // order of our curve. We add the 0x prefix as it's required by ethers.js
     const privateKeyMod = privateKeyFull.mod(`0x${ec.n.toString('hex')}`);
     // Remove 0x prefix to pad hex value, then add back 0x prefix
-    const privateKey = `0x${pad32ByteHex(privateKeyMod.toHexString().slice(2))}`;
+    const privateKey = `0x${padHex(privateKeyMod.toHexString().slice(2))}`;
     // Instantiate and return new instance
     return new KeyPair(privateKey);
   }

--- a/umbra-js/classes/KeyPair.js
+++ b/umbra-js/classes/KeyPair.js
@@ -5,28 +5,11 @@ const EC = require('elliptic').ec;
 const { Buffer } = require('buffer/');
 const { keccak256 } = require('js-sha3');
 const ethers = require('ethers');
+const { pad32ByteHex, recoverPublicKeyFromTransaction } = require('../utils/utils');
 
 const ec = new EC('secp256k1');
 const { utils } = ethers;
-const provider = ethers.getDefaultProvider();
 
-/**
- * @notice Adds leading zeroes to ensure 32-byte hex strings are the expected length.
- * @dev We always expect a hex value to have the full number of characters for its size,
- * so we use this tool to ensure no errors occur due to wrong hex character lengths.
- * Specifically, we need to pad hex values during the following cases:
- *   1. It seems elliptic strips unnecessary leading zeros when pulling out x and y
- *      coordinates from public keys.
- *   2. When computing a new private key from a random number, the new number (i.e. the new
- *      private key) may not necessarily require all 32-bytes as ethers.js also seems to
- *      strip leading zeroes.
- * @param {String} hex String to pad, without leading 0x
- */
-function pad32ByteHex(hex) {
-  if (!utils.isHexString) throw new Error('Input is not a valid hex string');
-  if (hex.slice(0, 2) === '0x') { throw new Error('Input must not contain 0x prefix'); }
-  return hex.padStart(64, 0);
-}
 
 class KeyPair {
   /**
@@ -65,6 +48,7 @@ class KeyPair {
     }
   }
 
+  // GETTERS =======================================================================================
   /**
    * @notice Returns the x,y public key coordinates as hex
    */
@@ -109,6 +93,7 @@ class KeyPair {
     return utils.getAddress(address);
   }
 
+  // ELLIPTIC CURVE MATH ===========================================================================
   /**
    * @notice Returns new KeyPair instance after multiplying this public key by some value
    * @param {RandomNumber} value number to multiply by, as class RandomNumber
@@ -140,52 +125,13 @@ class KeyPair {
     return new KeyPair(privateKey);
   }
 
-  /**
-  * @notice Given a transaction hash, return the public key of the transaction's sender
-  * @dev See https://github.com/ethers-io/ethers.js/issues/700 for an example of
-  * recovering public key from a transaction with ethers
-  * @param {String} txHash Transaction hash to recover public key from
-  */
-  static async recoverPublicKeyFromTransaction(txHash) {
-    // Get transaction data
-    const tx = await provider.getTransaction(txHash);
-
-    // Get original signature
-    const splitSignature = {
-      r: tx.r,
-      s: tx.s,
-      v: tx.v,
-    };
-    const signature = ethers.utils.joinSignature(splitSignature);
-
-    // Reconstruct transaction data that was originally signed
-    const txData = {
-      chainId: tx.chainId,
-      data: tx.data,
-      gasLimit: tx.gasLimit,
-      gasPrice: tx.gasPrice,
-      nonce: tx.nonce,
-      to: tx.to, // this works for both regular and contract transactions
-      value: tx.value,
-    };
-
-    // Properly format it to get the correct message
-    const resolvedTx = await ethers.utils.resolveProperties(txData);
-    const rawTx = ethers.utils.serializeTransaction(resolvedTx);
-    const msgHash = ethers.utils.keccak256(rawTx);
-    const msgBytes = ethers.utils.arrayify(msgHash);
-
-    // Recover sender's public key and address
-    const publicKey = ethers.utils.recoverPublicKey(msgBytes, signature);
-    return publicKey;
-  }
-
+  // STATIC METHODS ================================================================================
   /**
    * @notice Generate KeyPair instance asynchronously from a transaction hash
    * @param {String} txHash Transaction hash to recover public key from
    */
   static async instanceFromTransaction(txHash) {
-    const publicKeyHex = await this.recoverPublicKeyFromTransaction(txHash);
+    const publicKeyHex = await recoverPublicKeyFromTransaction(txHash);
     return new KeyPair(publicKeyHex);
   }
 }

--- a/umbra-js/classes/RandomNumber.js
+++ b/umbra-js/classes/RandomNumber.js
@@ -2,6 +2,7 @@
  * @notice Class for managing random numbers
  */
 const ethers = require('ethers');
+const { padHex } = require('../utils/utils');
 
 const { utils } = ethers;
 
@@ -11,6 +12,7 @@ class RandomNumber {
    * @param {Number} length Number of bytes random number should have
    */
   constructor(length = 32) {
+    this.length = length;
     this.value = utils.shuffled(utils.randomBytes(length));
   }
 
@@ -25,14 +27,14 @@ class RandomNumber {
    * @notice Get random number as hex string
    */
   get asHex() {
-    return this.asBN.toHexString();
+    return `0x${padHex(this.asBN.toHexString().slice(2), this.length)}`;
   }
 
   /**
    * @notice Get random number as hex string without 0x prefix
    */
   get asHexSlim() {
-    return this.asHex.slice(2);
+    return padHex(this.asHex.slice(2), this.length);
   }
 }
 

--- a/umbra-js/index.js
+++ b/umbra-js/index.js
@@ -1,7 +1,9 @@
 const KeyPair = require('./classes/KeyPair');
 const RandomNumber = require('./classes/RandomNumber');
+const utils = require('./utils/utils');
 
 module.exports = {
   KeyPair,
   RandomNumber,
+  utils,
 };

--- a/umbra-js/package-lock.json
+++ b/umbra-js/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "umbra-protocol",
+  "name": "umbra-js",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/umbra-js/package-lock.json
+++ b/umbra-js/package-lock.json
@@ -535,6 +535,24 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "optional": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -569,6 +587,20 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "optional": true,
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "buffer": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
@@ -577,6 +609,12 @@
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
       }
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "optional": true
     },
     "callsites": {
       "version": "3.1.0",
@@ -638,6 +676,16 @@
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.2.0"
+      }
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "optional": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "cli-cursor": {
@@ -717,6 +765,33 @@
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
     },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "optional": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "optional": true,
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -786,6 +861,50 @@
         "esutils": "^2.0.2"
       }
     },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "optional": true,
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
+    },
+    "eccrypto": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/eccrypto/-/eccrypto-1.1.3.tgz",
+      "integrity": "sha512-Xtyj039Xp2NDZwoe9IcD7pT1EwM4DILdxPCN2H7Rk1wgJNtTkFpk+cpX1QpuHTMaIhkatOBlGGKzGw/DUCDdqg==",
+      "requires": {
+        "acorn": "7.1.0",
+        "elliptic": "6.5.1",
+        "es6-promise": "4.2.8",
+        "nan": "2.14.0",
+        "secp256k1": "3.7.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+        },
+        "elliptic": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+          "integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        }
+      }
+    },
     "elliptic": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
@@ -840,6 +959,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1103,6 +1227,16 @@
         "@ethersproject/wordlists": ">=5.0.0-beta.128"
       }
     },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "optional": true,
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -1143,6 +1277,12 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -1276,6 +1416,17 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+    },
+    "hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "optional": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      }
     },
     "hash.js": {
       "version": "1.1.7",
@@ -1584,6 +1735,17 @@
         "chalk": "^2.4.2"
       }
     },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "optional": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -1750,6 +1912,11 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -2014,6 +2181,17 @@
         "read-pkg": "^2.0.0"
       }
     },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "optional": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "readdirp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
@@ -2070,6 +2248,16 @@
         "glob": "^7.1.3"
       }
     },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "optional": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -2083,6 +2271,12 @@
         "tslib": "^1.9.0"
       }
     },
+    "safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "optional": true
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2092,6 +2286,22 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.0.tgz",
       "integrity": "sha512-7CC7aufwukEvqdmllR0ny0QaSg0+S22xKXrXz3ZahaV6J+fgD2YAtrjtImuoDWog17/Ty9Q4HBmnXEXJ3JkfQA=="
+    },
+    "secp256k1": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "bip66": "^1.1.5",
+        "bn.js": "^4.11.8",
+        "create-hash": "^1.2.0",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.4.1",
+        "nan": "^2.14.0",
+        "safe-buffer": "^5.1.2"
+      }
     },
     "semver": {
       "version": "6.3.0",
@@ -2103,6 +2313,16 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "optional": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -2230,6 +2450,15 @@
         "es-abstract": "^1.17.5"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "optional": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -2354,6 +2583,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "optional": true
     },
     "uuid": {
       "version": "2.0.1",

--- a/umbra-js/package.json
+++ b/umbra-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "umbra-protocol",
+  "name": "umbra-js",
   "version": "0.0.1",
   "description": "Send and receive stealth payments",
   "main": "index.js",

--- a/umbra-js/package.json
+++ b/umbra-js/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "buffer": "^5.6.0",
+    "eccrypto": "^1.1.3",
     "elliptic": "^6.5.2",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.1.0",

--- a/umbra-js/test/KeyPair.test.js
+++ b/umbra-js/test/KeyPair.test.js
@@ -90,13 +90,19 @@ describe('KeyPair class', () => {
   });
 
   it('supports encryption and decryption of the random number', async () => {
-    // Encrypt payload
-    const number = new RandomNumber();
-    const encryptedMessage = await KeyPair.encrypt(publicKey, number);
-    // console.log(encryptedMessage);
-
-    const plaintext = await KeyPair.decrypt(privateKey, encryptedMessage);
-    // console.log(plaintext);
+    for (let i = 0; i < 20; i += 1) {
+      // Do a bunch of tests with random wallets and numbers
+      wallet = ethers.Wallet.createRandom();
+      // Encrypt payload
+      const number = new RandomNumber();
+      const payload = `umbra-protocol-v0${number.asHex}`;
+      const keyPairFromPublic = new KeyPair(wallet.publicKey);
+      const output = await keyPairFromPublic.encrypt(number); // eslint-disable-line no-await-in-loop
+      // Decrypt payload
+      const keyPairFromPrivate = new KeyPair(wallet.privateKey);
+      const plaintext = await keyPairFromPrivate.decrypt(output); // eslint-disable-line no-await-in-loop
+      expect(plaintext).to.equal(payload);
+    }
   });
 
   it('lets sender generate stealth receiving address that recipient can access', () => {

--- a/umbra-js/test/KeyPair.test.js
+++ b/umbra-js/test/KeyPair.test.js
@@ -8,8 +8,9 @@ const utils = require('../utils/utils');
 
 const { expect } = chai;
 
-// Address and private key from first deterministic ganache account
+// Address, public key, and private key from first deterministic ganache account
 const address = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1';
+const publicKey = '0x04e68acfc0253a10620dff706b0a1b1f1f5833ea3beb3bde2250d5f271f3563606672ebc45e0b7ea2e816ecb70ca03137b1c9476eec63d4632e990020b7b6fba39';
 const privateKey = '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d';
 
 describe('KeyPair class', () => {
@@ -86,6 +87,16 @@ describe('KeyPair class', () => {
     expect(keyPair1.publicKeyHeCoords).to.equal(keyPair2.publicKeyHeCoords);
     expect(keyPair1.publicKeyBN.toHexString()).to.equal(keyPair2.publicKeyBN.toHexString());
     expect(JSON.stringify(keyPair1.publicKeyEC)).to.equal(JSON.stringify(keyPair2.publicKeyEC));
+  });
+
+  it('supports encryption and decryption of the random number', async () => {
+    // Encrypt payload
+    const number = new RandomNumber();
+    const encryptedMessage = await KeyPair.encrypt(publicKey, number);
+    // console.log(encryptedMessage);
+
+    const plaintext = await KeyPair.decrypt(privateKey, encryptedMessage);
+    // console.log(plaintext);
   });
 
   it('lets sender generate stealth receiving address that recipient can access', () => {

--- a/umbra-js/test/KeyPair.test.js
+++ b/umbra-js/test/KeyPair.test.js
@@ -1,7 +1,10 @@
 const chai = require('chai');
 const ethers = require('ethers');
+
+// umbra-js components
 const KeyPair = require('../classes/KeyPair');
 const RandomNumber = require('../classes/RandomNumber');
+const utils = require('../utils/utils');
 
 const { expect } = chai;
 
@@ -62,7 +65,7 @@ describe('KeyPair class', () => {
     const txHash = '0x282a980bf2d7500233e4f2c55981e64826938cfe871060bfad9b22842adcb2c8';
     const sendersPublicKey = '0x04ef3718f57c441836d3adf7920b041c30b1394e00fd9be3eae0a3b5ff71709d6b93cc818a889a5ea1b9742d577b603e0d7a87feb9da4d49f0260d73f72af91dd9';
     // Create instance and check result
-    const recoveredPublicKey = await KeyPair.recoverPublicKeyFromTransaction(txHash);
+    const recoveredPublicKey = await utils.recoverPublicKeyFromTransaction(txHash);
     expect(recoveredPublicKey).to.equal(sendersPublicKey);
   });
 

--- a/umbra-js/test/RandomNumber.test.js
+++ b/umbra-js/test/RandomNumber.test.js
@@ -19,8 +19,12 @@ describe('RandomNumber class', () => {
   });
 
   it('allows random number instances to be initialized with different sizes', () => {
-    const random16 = new RandomNumber(16);
-    expect(random16.value.length).to.equal(16);
+    for (let i = 0; i < 1000; i += 1) {
+      const random16 = new RandomNumber(16);
+      expect(random16.value.length).to.equal(16);
+      expect(random16.asHex.length).to.equal(34);
+      expect(random16.asHexSlim.length).to.equal(32);
+    }
   });
 
   it('returns random value as an ethers BigNumber', () => {
@@ -28,15 +32,19 @@ describe('RandomNumber class', () => {
   });
 
   it('returns random value as a hex string', () => {
-    const hex = random.asHex;
-    expect(utils.isHexString(hex)).to.be.true;
-    // TODO: Sometimes fails with "expected 64 to equal 66"?
-    expect(hex.length).to.equal(66); // 32-bytes plus leading 0x prefix
+    for (let i = 0; i < 1000; i += 1) {
+      random = new RandomNumber();
+      const hex = random.asHex;
+      expect(utils.isHexString(hex)).to.be.true;
+      expect(hex.length).to.equal(66); // 32-bytes plus leading 0x prefix
+    }
   });
 
   it('returns random value as a hex string without the 0x prefix', () => {
-    const hex = random.asHexSlim;
-    // TODO: Sometimes fails with "expected 62 to equal 64"?
-    expect(hex.length).to.equal(64); // 32-bytes plus without 0x prefix
+    for (let i = 0; i < 1000; i += 1) {
+      random = new RandomNumber();
+      const hex = random.asHexSlim;
+      expect(hex.length).to.equal(64); // 32-bytes plus without 0x prefix
+    }
   });
 });

--- a/umbra-js/test/RandomNumber.test.js
+++ b/umbra-js/test/RandomNumber.test.js
@@ -36,6 +36,7 @@ describe('RandomNumber class', () => {
 
   it('returns random value as a hex string without the 0x prefix', () => {
     const hex = random.asHexSlim;
+    // TODO: Sometimes fails with "expected 62 to equal 64"?
     expect(hex.length).to.equal(64); // 32-bytes plus without 0x prefix
   });
 });

--- a/umbra-js/test/RandomNumber.test.js
+++ b/umbra-js/test/RandomNumber.test.js
@@ -30,6 +30,7 @@ describe('RandomNumber class', () => {
   it('returns random value as a hex string', () => {
     const hex = random.asHex;
     expect(utils.isHexString(hex)).to.be.true;
+    // TODO: Sometimes fails with "expected 64 to equal 66"?
     expect(hex.length).to.equal(66); // 32-bytes plus leading 0x prefix
   });
 

--- a/umbra-js/utils/utils.js
+++ b/umbra-js/utils/utils.js
@@ -4,7 +4,7 @@ const { utils } = ethers;
 const provider = ethers.getDefaultProvider();
 
 /**
- * @notice Adds leading zeroes to ensure 32-byte hex strings are the expected length.
+ * @notice Adds leading zeroes to ensure hex strings are the expected length.
  * @dev We always expect a hex value to have the full number of characters for its size,
  * so we use this tool to ensure no errors occur due to wrong hex character lengths.
  * Specifically, we need to pad hex values during the following cases:
@@ -13,12 +13,15 @@ const provider = ethers.getDefaultProvider();
  *   2. When computing a new private key from a random number, the new number (i.e. the new
  *      private key) may not necessarily require all 32-bytes as ethers.js also seems to
  *      strip leading zeroes.
+ *   3. When generating random numbers and returning them as hex strings, the leading
+ *      zero bytes get stripped
  * @param {String} hex String to pad, without leading 0x
+ * @param {String} bytes Number of bytes string should have
  */
-module.exports.pad32ByteHex = (hex) => {
+module.exports.padHex = (hex, bytes = 32) => {
   if (!utils.isHexString) throw new Error('Input is not a valid hex string');
   if (hex.slice(0, 2) === '0x') { throw new Error('Input must not contain 0x prefix'); }
-  return hex.padStart(64, 0);
+  return hex.padStart(bytes * 2, 0);
 };
 
 /**

--- a/umbra-js/utils/utils.js
+++ b/umbra-js/utils/utils.js
@@ -1,0 +1,62 @@
+const ethers = require('ethers');
+
+const { utils } = ethers;
+const provider = ethers.getDefaultProvider();
+
+/**
+ * @notice Adds leading zeroes to ensure 32-byte hex strings are the expected length.
+ * @dev We always expect a hex value to have the full number of characters for its size,
+ * so we use this tool to ensure no errors occur due to wrong hex character lengths.
+ * Specifically, we need to pad hex values during the following cases:
+ *   1. It seems elliptic strips unnecessary leading zeros when pulling out x and y
+ *      coordinates from public keys.
+ *   2. When computing a new private key from a random number, the new number (i.e. the new
+ *      private key) may not necessarily require all 32-bytes as ethers.js also seems to
+ *      strip leading zeroes.
+ * @param {String} hex String to pad, without leading 0x
+ */
+module.exports.pad32ByteHex = (hex) => {
+  if (!utils.isHexString) throw new Error('Input is not a valid hex string');
+  if (hex.slice(0, 2) === '0x') { throw new Error('Input must not contain 0x prefix'); }
+  return hex.padStart(64, 0);
+};
+
+/**
+  * @notice Given a transaction hash, return the public key of the transaction's sender
+  * @dev See https://github.com/ethers-io/ethers.js/issues/700 for an example of
+  * recovering public key from a transaction with ethers
+  * @param {String} txHash Transaction hash to recover public key from
+  */
+module.exports.recoverPublicKeyFromTransaction = async (txHash) => {
+  // Get transaction data
+  const tx = await provider.getTransaction(txHash);
+
+  // Get original signature
+  const splitSignature = {
+    r: tx.r,
+    s: tx.s,
+    v: tx.v,
+  };
+  const signature = ethers.utils.joinSignature(splitSignature);
+
+  // Reconstruct transaction data that was originally signed
+  const txData = {
+    chainId: tx.chainId,
+    data: tx.data,
+    gasLimit: tx.gasLimit,
+    gasPrice: tx.gasPrice,
+    nonce: tx.nonce,
+    to: tx.to, // this works for both regular and contract transactions
+    value: tx.value,
+  };
+
+  // Properly format it to get the correct message
+  const resolvedTx = await ethers.utils.resolveProperties(txData);
+  const rawTx = ethers.utils.serializeTransaction(resolvedTx);
+  const msgHash = ethers.utils.keccak256(rawTx);
+  const msgBytes = ethers.utils.arrayify(msgHash);
+
+  // Recover sender's public key and address
+  const publicKey = ethers.utils.recoverPublicKey(msgBytes, signature);
+  return publicKey;
+};

--- a/umbra-js/utils/utils.js
+++ b/umbra-js/utils/utils.js
@@ -22,6 +22,12 @@ module.exports.pad32ByteHex = (hex) => {
 };
 
 /**
+ * @notice Convert hex string with 0x prefix into Buffer
+ * @param {String} data Hex string to convert
+ */
+module.exports.hexStringToBuffer = (data) => Buffer.from(utils.arrayify(data));
+
+/**
   * @notice Given a transaction hash, return the public key of the transaction's sender
   * @dev See https://github.com/ethers-io/ethers.js/issues/700 for an example of
   * recovering public key from a transaction with ethers


### PR DESCRIPTION
- Adds ECIES encryption to KeyPair class, implemented with [`eccrypto`](https://github.com/bitchan/eccrypto/)
- Rename package from `umbra-protocol` to `umbra-js`
- Fix bug in random number class where returned hex strings would have leading zeros truncated.

Encryption/decryption requires the `Buffer` class which works in node, but does not exist natively in the browser. Will add support for that in a separate PR.