### PR TITLE
Implement pbkdf

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -4318,6 +4318,14 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
+    "browser-passworder": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/browser-passworder/-/browser-passworder-2.0.3.tgz",
+      "integrity": "sha1-b90gguUWoXbtvLPc7gt/n85PeRc=",
+      "requires": {
+        "browserify-unibabel": "^3.0.0"
+      }
+    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -4388,6 +4396,11 @@
         "parse-asn1": "^5.1.5",
         "readable-stream": "^3.6.0"
       }
+    },
+    "browserify-unibabel": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-unibabel/-/browserify-unibabel-3.0.0.tgz",
+      "integrity": "sha1-WmuPD3BM44jTkn30czfiWDD3Hdo="
     },
     "browserify-zlib": {
       "version": "0.2.0",

--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@quasar/extras": "^1.0.0",
+    "browser-passworder": "^2.0.3",
     "ethers": "^5.0.0-beta.185",
     "quasar": "^1.0.0"
   },

--- a/app/src/components/AccountSetupChoosePassword.vue
+++ b/app/src/components/AccountSetupChoosePassword.vue
@@ -1,0 +1,53 @@
+<template>
+  <div>
+    To maximize privacy and security, we'll generate a random private key that
+    will be used to manage your Umbra account. This key will be encrypted based
+    on your chosen password.
+
+    <div
+      class="q-mt-lg"
+      style="max-width: 350px"
+    >
+      <base-input
+        v-model="password1"
+        label="Enter Password"
+        :rules="isValidPassword1"
+        type="password"
+      />
+      <base-input
+        v-model="password2"
+        label="Confirm Password"
+        :lazy-rules="false"
+        :rules="isValidPassword2"
+        type="password"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AccountSetupChoosePassword',
+
+  data() {
+    return {
+      password1: undefined,
+      password2: undefined,
+    };
+  },
+
+  methods: {
+    isValidPassword1() {
+      if (!this.password1) return 'Please enter a password';
+      return this.password1.length > 7 || 'Password must be at least 8 characters';
+    },
+    isValidPassword2() {
+      if (!this.password2) return 'Passwords do not match';
+      const isValid = this.password1 === this.password2;
+      // NOTE: Mutation performed here
+      if (isValid) this.$store.commit('user/setPassword', this.password1);
+      return isValid || 'Passwords do not match';
+    },
+  },
+};
+</script>

--- a/app/src/components/AccountSetupEnsCheck.vue
+++ b/app/src/components/AccountSetupEnsCheck.vue
@@ -25,7 +25,7 @@
         <br>
         <span class="text-caption">The ENS domain
           <span class="text-bold">{{ userEnsDomain }}</span>
-          resolves to this address. Please continue to Step 2.
+          resolves to this address. Please continue to the next step.
         </span>
       </div>
       <div v-else>
@@ -38,7 +38,7 @@
         sure the reverse record is set.
         <br>
         <span class="text-caption">
-          Either navigate to the home page, refresh, and login with a different address,
+          Either login with a different address and refresh the page,
           or follow
           <a
             class="hyperlink"
@@ -46,7 +46,7 @@
             target="_blank"
           >this guide</a>
           to learn how to purchase a domain and configure it to resolve to
-          your Ethereum address.
+          your Ethereum address. Be sure to use the Public Resolver and set the reverse record
         </span>
       </div>
     </div>

--- a/app/src/components/AccountSetupPrivateKey.vue
+++ b/app/src/components/AccountSetupPrivateKey.vue
@@ -1,0 +1,87 @@
+<template>
+  <div>
+    Download a copy of your encrypted private key and save it on your computer.
+    This is your backup in case your browser storage is lost or cleared.
+    <span class="header-black">Do not lose this file or forget your password!</span>
+
+    <base-button
+      class="q-my-lg"
+      label="Download File"
+      @click="downloadFile"
+    />
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import { exportFile } from 'quasar';
+import { ethers } from 'ethers';
+import cryptography from 'src/mixins/cryptography';
+import helpers from 'src/mixins/helpers';
+
+export default {
+  name: 'AccountSetupPrivateKey',
+
+  mixins: [cryptography, helpers],
+
+  data() {
+    return {};
+  },
+
+  computed: {
+    ...mapState({
+      userAddress: (state) => state.user.userAddress,
+      password: (state) => state.user.sensitive.password,
+    }),
+  },
+
+  async created() {
+    try {
+      // Generate random wallet
+      const wallet = ethers.Wallet.createRandom();
+
+      // Encrypt private key and corresponding web3 wallet
+      const data = {
+        privateKey: wallet.privateKey, // randomly generated private key
+        expectedWeb3Address: this.userAddress, // web3 wallet user is logged in with
+      };
+      const encrypted = await this.encryptPrivateKey(this.password, data);
+
+      // Save to localStorage, read from localStorage, and decrypt to confirm everything worked
+      this.$q.localStorage.set('umbra-data', encrypted);
+      const localStorageData = this.$q.localStorage.getItem('umbra-data');
+      const decrypted = await this.decryptPrivateKey(this.password, localStorageData);
+
+      const isPrivateKeyEqual = data.privateKey === decrypted.privateKey;
+      const isExpectedWeb3AddressEqual = data.expectedWeb3Address === decrypted.expectedWeb3Address;
+      const wasSuccessful = isPrivateKeyEqual && isExpectedWeb3AddressEqual;
+
+      // TODO clear state and localStorage if something went wrong
+      if (!wasSuccessful) {
+        throw new Error('Something went wrong during account setup. Please refresh the page and try again.');
+      }
+
+      // Save private key to state so we can sign message later
+      this.$store.commit('user/setPrivateKey', wallet.privateKey);
+    } catch (err) {
+      this.showError(err);
+    }
+  },
+
+  methods: {
+    /**
+     * @notice Prompt user to save a file with the encrypted data
+     */
+    async downloadFile() {
+      try {
+        const encrypted = this.$q.localStorage.getItem('umbra-data');
+        const status = exportFile('umbra-data.txt', encrypted);
+        if (!status) throw new Error(`Broswer blocked file download: ${status}`);
+        this.$store.commit('user/setFileDownloadStatus', status);
+      } catch (err) {
+        this.showError(err);
+      }
+    },
+  },
+};
+</script>

--- a/app/src/components/BaseButton.vue
+++ b/app/src/components/BaseButton.vue
@@ -4,6 +4,7 @@
       class="q-my-sm"
       :class="{'full-width': fullWidth}"
       :color="color"
+      :disable="disable"
       :dense="dense"
       :flat="flat"
       :label="label"
@@ -26,6 +27,12 @@ export default {
     },
 
     dense: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+
+    disable: {
       type: Boolean,
       required: false,
       default: false,

--- a/app/src/components/BaseInput.vue
+++ b/app/src/components/BaseInput.vue
@@ -4,6 +4,8 @@
       v-model="content"
       class="q-my-sm"
       filled
+      :dense="dense"
+      :hide-bottom-space="hideBottomSpace"
       :label="label"
       :lazy-rules="lazyRules"
       :rules="[val => rules(val)]"
@@ -29,10 +31,22 @@ export default {
   name: 'BaseInput',
 
   props: {
+    dense: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+
     iconAppend: {
       type: String,
       required: false,
       default: undefined,
+    },
+
+    hideBottomSpace: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
 
     label: {

--- a/app/src/components/InputPrivateKey.vue
+++ b/app/src/components/InputPrivateKey.vue
@@ -1,12 +1,10 @@
 <template>
-  <div>
-    <base-input
-      v-model="privateKey"
-      label="Your Private Key"
-      :lazy-rules="false"
-      :rules="isValidPrivateKey"
-    />
-  </div>
+  <base-input
+    v-model="privateKey"
+    label="Enter Private Key"
+    :lazy-rules="false"
+    :rules="isValidPrivateKey"
+  />
 </template>
 
 <script>

--- a/app/src/components/TheTutorial.vue
+++ b/app/src/components/TheTutorial.vue
@@ -13,33 +13,15 @@
         To Receive Funds
       </h5>
       <ol>
-        <li>Create a new account with MetaMask</li>
+        <li>Choose a MetaMask account to associate with Umbra</li>
         <li>
-          Using that account, purchase and configure an ENS domain on Ropsten
-          (this is optional, but recommended for additional privacy)
-          <ol>
-            <li>
-              See
-              <a
-                href="https://docs.ethhub.io/guides/guide-to-ens/"
-                target="_blank"
-                class="hyperlink"
-              >this guide</a>
-              for instructions on purchasing and configuring your ENS domain
-            </li>
-            <li> Make sure to set the resolver to the Public Resolver </li>
-            <li> Make sure to set the reverse record </li>
-          </ol>
-        </li>
-        <li>Login to the Umbra app with that account</li>
-        <li>
-          If using ENS, navigate to the ENS Setup page and follow the steps.
-          Once you see green checkmarks in both steps, ENS setup is complete.
+          Click Account Setup and follow the setup wizard (this is optional,
+          but recommended for additional security and privacy)
         </li>
         <li>
-          To receive funds, give the recipient any one of the following identifiers:
+          To receive funds any one of the following identifiers:
           <ul>
-            <li>Your configured ENS domain</li>
+            <li>Your configured ENS domain (recommended)</li>
             <li>Your public Ethereum address</li>
             <li>A transaction hash from a transaction you sent</li>
             <li>Your full public key</li>
@@ -56,7 +38,6 @@
       </h5>
       <ol>
         <li>Ask the recipient for their preferred identifier </li>
-        <li>Login to Umbra with the account you'd like to send funds from</li>
         <li>Navigate to the Send page and follow the prompts</li>
       </ol>
     </div>

--- a/app/src/components/UnlockAccount.vue
+++ b/app/src/components/UnlockAccount.vue
@@ -1,0 +1,95 @@
+<template>
+  <div>
+    <div class="row justify-center items-center">
+      <div class="col-auto q-mr-sm">
+        <base-input
+          v-model="password"
+          :dense="true"
+          :hide-bottom-space="true"
+          label="Enter Password"
+          style="min-width: 300px"
+          type="password"
+        />
+      </div>
+      <div>
+        <base-button
+          class="col-auto q-ml-sm"
+          label="Check"
+          :disabled="!password"
+          :loading="isCheckingStatus"
+          @click="checkSetupStatus"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import cryptography from 'src/mixins/cryptography';
+import helpers from 'src/mixins/helpers';
+
+const umbra = require('umbra-js');
+
+const { ens, KeyPair } = umbra;
+
+export default {
+  name: 'UnlockAccount',
+
+  mixins: [cryptography, helpers],
+
+  data() {
+    return {
+      isCheckingStatus: undefined,
+      password: undefined,
+    };
+  },
+
+  computed: {
+    ...mapState({
+      provider: (state) => state.user.provider,
+      userAddress: (state) => state.user.userAddress,
+      userEnsDomain: (state) => state.user.userEnsDomain,
+    }),
+  },
+
+  methods: {
+    async checkSetupStatus() {
+      try {
+        this.isCheckingStatus = true;
+        // Decrypt data
+        const encryptedData = this.$q.localStorage.getItem('umbra-data');
+        const data = await this.decryptPrivateKey(this.password, encryptedData);
+
+        // Ensure addresses match
+        if (this.userAddress !== data.expectedWeb3Address) {
+          throw new Error('Wrong web3 account detected. Please switch to the correct web3 account and try again.');
+        }
+
+        // Get public key from the private key in local storage
+        const keyPair = new KeyPair(data.privateKey);
+        const publicKey1 = keyPair.publicKeyHex;
+
+        // Get public key from the ENS address
+        if (!this.userEnsDomain) {
+          throw new Error('No ENS Account configured for the connected web3 account.');
+        }
+        const publicKey2 = await ens.getPublicKey(this.userEnsDomain, this.provider);
+        this.isCheckingStatus = false;
+
+        // Compare public keys
+        if (publicKey1 !== publicKey2) {
+          throw new Error('The locally saved key does not match the key associated with the ENS address.');
+        }
+
+        // Everything checks out
+        this.$store.commit('user/setPrivateKey', data.privateKey);
+        this.$emit('unlocked');
+      } catch (err) {
+        this.showError(err);
+        this.isCheckingStatus = false;
+      }
+    },
+  },
+};
+</script>

--- a/app/src/components/UnlockAccount.vue
+++ b/app/src/components/UnlockAccount.vue
@@ -1,26 +1,18 @@
 <template>
   <div>
-    <div class="row justify-center items-center">
-      <div class="col-auto q-mr-sm">
-        <base-input
-          v-model="password"
-          :dense="true"
-          :hide-bottom-space="true"
-          label="Enter Password"
-          style="min-width: 300px"
-          type="password"
-        />
-      </div>
-      <div>
-        <base-button
-          class="col-auto q-ml-sm"
-          label="Check"
-          :disabled="!password"
-          :loading="isCheckingStatus"
-          @click="checkSetupStatus"
-        />
-      </div>
-    </div>
+    <base-input
+      v-model="password"
+      label="Enter Password"
+      style="min-width: 300px"
+      type="password"
+    />
+    <base-button
+      :label="buttonLabel"
+      :disabled="!password"
+      :full-width="true"
+      :loading="isCheckingStatus"
+      @click="checkSetupStatus"
+    />
   </div>
 </template>
 
@@ -37,6 +29,14 @@ export default {
   name: 'UnlockAccount',
 
   mixins: [cryptography, helpers],
+
+  props: {
+    buttonLabel: {
+      type: String,
+      required: false,
+      default: 'Check',
+    },
+  },
 
   data() {
     return {

--- a/app/src/mixins/cryptography.js
+++ b/app/src/mixins/cryptography.js
@@ -1,0 +1,23 @@
+/**
+ * @notice This mixin contains cryptographic functions
+ */
+const passworder = require('browser-passworder');
+
+
+export default {
+  data() {
+    return {};
+  },
+
+  methods: {
+    async encryptPrivateKey(password, dataToEncrypt) {
+      const encrypted = await passworder.encrypt(password, dataToEncrypt);
+      return encrypted;
+    },
+
+    async decryptPrivateKey(password, dataToDecrypt) {
+      const decrypted = await passworder.decrypt(password, dataToDecrypt);
+      return decrypted;
+    },
+  },
+};

--- a/app/src/pages/Home.vue
+++ b/app/src/pages/Home.vue
@@ -37,7 +37,7 @@
         @click="navigateToPage('setup')"
       >
         <q-card-section class="text-h6 header-black card-header">
-          ENS Setup
+          Account Setup
         </q-card-section>
       </q-card>
     </div>

--- a/app/src/pages/Setup.vue
+++ b/app/src/pages/Setup.vue
@@ -53,21 +53,18 @@
 
           <q-step
             :name="3"
-            title="ENS Domain Setup"
-            icon="fas fa-user-cog"
-            disable
+            title="Save Key"
+            icon="fas fa-key"
           >
-            <account-setup-ens-config />
+            TODO
           </q-step>
 
           <q-step
             :name="4"
-            title="Create an ad"
-            icon="add_comment"
+            title="ENS Domain Setup"
+            icon="fas fa-user-cog"
           >
-            Try out different ad text to see what brings in the most customers, and learn how to
-            enhance your ads using features like ad extensions. If you run into any problems with
-            your ads, find out how to tell if they're running and how to resolve approval issues.
+            <account-setup-ens-config />
           </q-step>
 
           <template v-slot:navigation>
@@ -123,11 +120,14 @@ export default {
       userAddress: (state) => state.user.userAddress,
       userEnsDomain: (state) => state.user.userEnsDomain,
       chainId: (state) => state.user.provider.chainId,
+      sensitive: (state) => state.user.sensitive,
     }),
 
     isStepComplete() {
       if (this.step === 1) {
         return !!this.userEnsDomain;
+      } if (this.step === 2) {
+        return !!this.sensitive.password;
       }
       return false;
     },

--- a/app/src/pages/Setup.vue
+++ b/app/src/pages/Setup.vue
@@ -55,8 +55,9 @@
             :name="3"
             title="Save Key"
             icon="fas fa-key"
+            :done="step > 3"
           >
-            TODO
+            <account-setup-private-key />
           </q-step>
 
           <q-step
@@ -96,6 +97,7 @@ import { mapState } from 'vuex';
 import AccountSetupChoosePassword from 'components/AccountSetupChoosePassword';
 import AccountSetupEnsCheck from 'components/AccountSetupEnsCheck';
 import AccountSetupEnsConfig from 'components/AccountSetupEnsConfig';
+import AccountSetupPrivateKey from 'components/AccountSetupPrivateKey';
 import ConnectWallet from 'components/ConnectWallet';
 
 export default {
@@ -106,6 +108,7 @@ export default {
     AccountSetupChoosePassword,
     AccountSetupEnsCheck,
     AccountSetupEnsConfig,
+    AccountSetupPrivateKey,
   },
 
   data() {
@@ -124,11 +127,9 @@ export default {
     }),
 
     isStepComplete() {
-      if (this.step === 1) {
-        return !!this.userEnsDomain;
-      } if (this.step === 2) {
-        return !!this.sensitive.password;
-      }
+      if (this.step === 1) return !!this.userEnsDomain;
+      if (this.step === 2) return !!this.sensitive.password;
+      if (this.step === 3) return !!this.sensitive.wasPrivateKeyDownloaded;
       return false;
     },
   },
@@ -142,8 +143,7 @@ export default {
       this.isAccountSetupComplete = false;
       return;
     }
-    console.log(1);
-    // this.$q.localStorage.set('umbra-data', 123);
+    this.isAccountSetupComplete = true;
   },
 };
 </script>

--- a/app/src/pages/Setup.vue
+++ b/app/src/pages/Setup.vue
@@ -30,10 +30,10 @@
     >
       <div
         v-if="!sensitive.privateKey"
-        class="text-center"
+        class="form text-justify"
       >
-        Your account may have already been setup. Please enter your password below to confirm.
-        <unlock-account />
+        Your account may have already been setup. To confirm, please enter your password below.
+        <unlock-account button-label="Check" />
       </div>
 
       <div

--- a/app/src/pages/Setup.vue
+++ b/app/src/pages/Setup.vue
@@ -4,6 +4,18 @@
       Account Setup
     </h3>
 
+    <div
+      class="text-center text-bold"
+      style="margin:0 auto"
+    >
+      Because this is alpha software, these steps must be completed in one sitting. If you
+      leave mid-setup, you must start the process over.
+    </div>
+
+    <div class="text-center q-my-md">
+      The whole setup process will only take 1&ndash;2 minutes.
+    </div>
+
     <!-- IF WALLET IS NOT CONNECTED -->
     <div
       v-if="!userAddress"
@@ -71,10 +83,18 @@
           <template v-slot:navigation>
             <q-stepper-navigation class="row justify-start">
               <base-button
+                v-if="step < 4"
                 color="primary"
                 :disable="!isStepComplete"
-                :label="step === 4 ? 'Finish' : 'Continue'"
+                label="Continue"
                 @click="$refs.stepper.next()"
+              />
+              <base-button
+                v-else-if="step === 4"
+                color="primary"
+                :disable="!isStepComplete"
+                label="Finish"
+                @click="$router.push({name: 'home'})"
               />
               <base-button
                 v-if="step > 1"
@@ -122,6 +142,7 @@ export default {
     ...mapState({
       userAddress: (state) => state.user.userAddress,
       userEnsDomain: (state) => state.user.userEnsDomain,
+      isEnsConfigured: (state) => state.user.isEnsConfigured,
       chainId: (state) => state.user.provider.chainId,
       sensitive: (state) => state.user.sensitive,
     }),
@@ -130,6 +151,7 @@ export default {
       if (this.step === 1) return !!this.userEnsDomain;
       if (this.step === 2) return !!this.sensitive.password;
       if (this.step === 3) return !!this.sensitive.wasPrivateKeyDownloaded;
+      if (this.step === 4) return !!this.isEnsConfigured;
       return false;
     },
   },

--- a/app/src/pages/Withdraw.vue
+++ b/app/src/pages/Withdraw.vue
@@ -20,12 +20,12 @@
       </div>
       <unlock-account @unlocked="searchForFunds" />
 
-      <div class="row justify-end q-mt-xl">
+      <div class="row justify-center q-mt-xl">
         <div
           class="text-caption hyperlink"
           @click="toggleInputMethod"
         >
-          Login with Umbra password
+          Login with private key
         </div>
       </div>
     </div>
@@ -50,12 +50,12 @@
         />
       </div>
 
-      <div class="row justify-end q-mt-xl">
+      <div class="row justify-center q-mt-xl">
         <div
-          class="text-caption hyperlink"
+          class="text-caption text-center hyperlink"
           @click="toggleInputMethod"
         >
-          Manually enter private key
+          Login with Umbra password
         </div>
       </div>
     </div>

--- a/app/src/pages/Withdraw.vue
+++ b/app/src/pages/Withdraw.vue
@@ -15,10 +15,14 @@
     </div>
 
     <div v-else-if="isUmbraPrivateKeyLogin && !isScanning">
-      <div class="text-center">
-        Enter your password to continue
+      <div class="form text-justify">
+        Enter your password and we'll scan the blockchain for funds
+        sent to a stealth address you control.
+        <unlock-account
+          button-label="Search for Funds"
+          @unlocked="searchForFunds"
+        />
       </div>
-      <unlock-account @unlocked="searchForFunds" />
 
       <div class="row justify-center q-mt-xl">
         <div
@@ -36,7 +40,7 @@
     >
       <div class="form">
         <div>
-          Enter the private key associated with your public identifier, and we'll
+          Enter the private key associated with your public identifier and we'll
           scan the blockchain for funds sent to a stealth address you control.
         </div>
         <input-private-key />

--- a/app/src/pages/Withdraw.vue
+++ b/app/src/pages/Withdraw.vue
@@ -14,37 +14,64 @@
       </div>
     </div>
 
+    <div v-else-if="isUmbraPrivateKeyLogin && !isScanning">
+      <div class="text-center">
+        Enter your password to continue
+      </div>
+      <unlock-account @unlocked="searchForFunds" />
+
+      <div class="row justify-end q-mt-xl">
+        <div
+          class="text-caption hyperlink"
+          @click="toggleInputMethod"
+        >
+          Login with Umbra password
+        </div>
+      </div>
+    </div>
+
     <div
-      v-else
-      class="form text-center"
+      v-else-if="!isUmbraPrivateKeyLogin && !isScanning"
+      class="text-center"
     >
-      <div>
-        Enter the private key associated with your public identifier, and we'll
-        scan the blockchain for funds sent to a stealth address you control.
-      </div>
-      <input-private-key />
+      <div class="form">
+        <div>
+          Enter the private key associated with your public identifier, and we'll
+          scan the blockchain for funds sent to a stealth address you control.
+        </div>
+        <input-private-key />
 
-      <base-button
-        :disabled="!privateKey"
-        :full-width="true"
-        label="Search For Funds"
-        :loading="isScanning"
-        @click="searchForFunds"
-      />
-
-      <div v-if="isScanning">
-        Scanning...
-        <br>
-        TODO
-        <ol>
-          <li>Check localstorage to see last block scanned from</li>
-          <li>Scan for all Announcement events and parse out parameters</li>
-          <li>Call `decrypt` on each set of outputs</li>
-          <li>If decrypted outputed starts with `umbra-protocol-v0`, it's for this private key</li>
-          <li>Save off block number of the last scanned block in localstorage</li>
-          <li>Show list a table of accessible funds with the option to withdraw</li>
-        </ol>
+        <base-button
+          :disabled="!privateKey"
+          :full-width="true"
+          label="Search For Funds"
+          :loading="isScanning"
+          @click="searchForFunds"
+        />
       </div>
+
+      <div class="row justify-end q-mt-xl">
+        <div
+          class="text-caption hyperlink"
+          @click="toggleInputMethod"
+        >
+          Manually enter private key
+        </div>
+      </div>
+    </div>
+
+    <div v-if="isScanning">
+      Scanning...
+      <br>
+      TODO
+      <ol>
+        <li>Check localstorage to see last block scanned from</li>
+        <li>Scan for all Announcement events and parse out parameters</li>
+        <li>Call `decrypt` on each set of outputs</li>
+        <li>If decrypted outputed starts with `umbra-protocol-v0`, it's for this private key</li>
+        <li>Save off block number of the last scanned block in localstorage</li>
+        <li>Show list a table of accessible funds with the option to withdraw</li>
+      </ol>
     </div>
   </q-page>
 </template>
@@ -53,6 +80,7 @@
 import { mapState } from 'vuex';
 import ConnectWallet from 'components/ConnectWallet';
 import InputPrivateKey from 'components/InputPrivateKey';
+import UnlockAccount from 'components/UnlockAccount';
 import umbra from 'umbra-js';
 
 const { KeyPair } = umbra;
@@ -63,11 +91,13 @@ export default {
   components: {
     ConnectWallet,
     InputPrivateKey,
+    UnlockAccount,
   },
 
   data() {
     return {
       isScanning: undefined,
+      isUmbraPrivateKeyLogin: true,
     };
   },
 
@@ -87,6 +117,10 @@ export default {
     searchForFunds() {
       this.isScanning = true;
       // this.isScanning = false;
+    },
+
+    toggleInputMethod() {
+      this.isUmbraPrivateKeyLogin = !this.isUmbraPrivateKeyLogin;
     },
   },
 };

--- a/app/src/store/user/mutations.js
+++ b/app/src/store/user/mutations.js
@@ -26,3 +26,7 @@ export function setPrivateKey(state, key) {
 export function setPassword(state, password) {
   state.sensitive.password = password;
 }
+
+export function setFileDownloadStatus(state, wasPrivateKeyDownloaded) {
+  state.sensitive.wasPrivateKeyDownloaded = wasPrivateKeyDownloaded;
+}

--- a/app/src/store/user/mutations.js
+++ b/app/src/store/user/mutations.js
@@ -30,3 +30,7 @@ export function setPassword(state, password) {
 export function setFileDownloadStatus(state, wasPrivateKeyDownloaded) {
   state.sensitive.wasPrivateKeyDownloaded = wasPrivateKeyDownloaded;
 }
+
+export function setEnsStatus(state, isEnsConfigured) {
+  state.isEnsConfigured = isEnsConfigured;
+}

--- a/app/src/store/user/mutations.js
+++ b/app/src/store/user/mutations.js
@@ -19,6 +19,10 @@ export function setPrivateKey(state, key) {
   const startsWith0x = key.slice(0, 2) === '0x';
   const isCorrectLength = key.length === 66;
   const isValid = isHex && startsWith0x && isCorrectLength;
-  if (isValid) state.privateKey = key;
-  else state.privateKey = undefined;
+  if (isValid) state.sensitive.privateKey = key;
+  else state.sensitive.privateKey = undefined;
+}
+
+export function setPassword(state, password) {
+  state.sensitive.password = password;
 }

--- a/app/src/store/user/state.js
+++ b/app/src/store/user/state.js
@@ -8,6 +8,7 @@ export default function () {
     ethersProvider: undefined,
     userAddress: undefined,
     userEnsDomain: undefined,
+    isEnsConfigured: undefined,
     // Sensitive info
     sensitive: {
       password: undefined,

--- a/app/src/store/user/state.js
+++ b/app/src/store/user/state.js
@@ -8,6 +8,10 @@ export default function () {
     ethersProvider: undefined,
     userAddress: undefined,
     userEnsDomain: undefined,
-    privateKey: undefined,
+    // Sensitive info
+    sensitive: {
+      password: undefined,
+      privateKey: undefined,
+    },
   };
 }

--- a/app/src/store/user/state.js
+++ b/app/src/store/user/state.js
@@ -12,6 +12,7 @@ export default function () {
     sensitive: {
       password: undefined,
       privateKey: undefined,
+      wasPrivateKeyDownloaded: undefined,
     },
   };
 }


### PR DESCRIPTION
Closes #15

Updated the account setup process to walk through the steps outlined in #15. The withdraw process is also implemented, but without steps 10–16 where we scan the blockchain for announcements.

Before testing, you'll need to remove the `vnd.umbra-v0-signature` record from your Ropsten ENS account. You can do this at https://app.ens.domains/name/yourDomain.eth

Note that this PR only covers the initial implementation, and I want to take another pass at the code for security reasons (e.g. minimizing the time unencrypted data is stored in state)