### PR TITLE
Save Gas By Removing Unnecessary Stealth Address Re-use Flag

### DIFF
--- a/contracts/contracts/Umbra.sol
+++ b/contracts/contracts/Umbra.sol
@@ -105,7 +105,7 @@ contract Umbra is BaseRelayRecipient, IKnowForwarderAddress, Ownable {
     require(msg.value == toll, "Umbra: Must pay the exact toll");
     require(
       tokenPayments[_receiver].amount == 0,
-      "Umbra: Cannot resend tokens to used stealth address"
+      "Umbra: Cannot send more tokens to stealth address"
       );
 
     tokenPayments[_receiver] = TokenPayment({token: _tokenAddr, amount: _amount});

--- a/contracts/test/umbra-test.js
+++ b/contracts/test/umbra-test.js
@@ -9,11 +9,6 @@ const { argumentBytes } = require('./sample-data');
 const { toWei } = web3.utils;
 const { BN } = web3.utils;
 
-// TODO NEXT: Enable token re-use and adjust existing tests. Is there a test sending ETH to
-// a Token receiver? There probs should be. Also, need to test withdraw after receiving multiple
-// sends, and also receving an additional send after withdrawing previous sends. Also, should
-// disallow withdraw if balance 0. Etc...
-
 describe('Umbra', () => {
   const [
     owner,
@@ -27,13 +22,24 @@ describe('Umbra', () => {
     other,
   ] = accounts;
 
+  // Toll value at contract deployment
   const deployedToll = toWei('0.01', 'ether');
+
+  // Toll value after update by administrator
   const updatedToll = toWei('0.001', 'ether');
+
+  // Eth amounts used in specific payments during test execution
   const ethPayment = toWei('1.6', 'ether');
   const secondEthPayment = toWei('7.5', 'ether');
+
+  // Token amounts used in specific payments during test execution
   const tokenAmount = toWei('100', 'ether');
   const secondTokenAmount = toWei('4.1', 'ether');
+
+  // The total token amount that will be held by the contract at any one time during test execution
   const totalTokenAmount = ( (new BN(tokenAmount)).add(new BN(secondTokenAmount)) ).toString();
+
+  // The amount of tokens that need to be minted to the payer for full test execution
   const mintTokenAmount = ( (new BN(totalTokenAmount)).add(new BN(tokenAmount)) ).toString();
 
   before(async () => {
@@ -264,7 +270,7 @@ describe('Umbra', () => {
         ...argumentBytes,
         { from: payer2, value: toll },
       ),
-      'Umbra: Cannot resend tokens to used stealth address',
+      'Umbra: Cannot send more tokens to stealth address',
     );
   });
 


### PR DESCRIPTION
The primary goal of this change is to prevent the need for an
extra flag, written to storage during Umbra sends, formerly used to
prevent stealth address re-use.

In normal usage of the protocol, addresses would not be re-used, but
someone could call the contract methods with an address that had already
received funds. There is no downside to this, except in the case of token
payments, where the funds are held in the contract until withdrawn, and
the balance of each stealth address is held in the contract. In such a
case, re-using the address would cause the prior balance data to be
overwritten, effectively locking the funds.

The motivation for this change is to save gas. We want to avoid the extra
storage write without the risk of locked funds. To do this, we:

1. Allow re-use of addresses when the asset being sent is ETH. There is no
  downside to doing so and no risk of funds being locked, since they are
  simply forwarded to the stealth address
2. Use a non-zero current-token balance as a check to prevent address reuse
   in the specific case that the user has not yet withdrawn their tokens.
   This prevents funds from being locked, w/o writing extra data.