### PR TITLE
Add ability to customize chainConfig

### DIFF
--- a/umbra-js/src/types.ts
+++ b/umbra-js/src/types.ts
@@ -3,11 +3,8 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { Event, Overrides } from '@ethersproject/contracts';
 import { JsonRpcProvider, Web3Provider } from '@ethersproject/providers';
 
+// ========================================= Ethers types ==========================================
 export { SignatureLike } from '@ethersproject/bytes';
-
-export interface UmbraOverrides extends Overrides {
-  payloadExtension?: string;
-}
 
 export type ExternalProvider =
   | ethers.providers.ExternalProvider
@@ -15,11 +12,25 @@ export type ExternalProvider =
 
 export type EthersProvider = Web3Provider | JsonRpcProvider;
 
-export type EnsNamehash = {
-  hash: (name: string) => string;
-  normalize: (name: string) => string;
-};
+// ======================================= Umbra class types =======================================
+// Settings when instantiating an instance of the Umbra class
+export interface ChainConfig {
+  umbraAddress: string; // address of Umbra contract
+  startBlock: number; // block Umbra contract was deployed at
+}
 
+// Overrides when sending or withdrawing funds
+export interface UmbraOverrides extends Overrides {
+  payloadExtension?: string;
+}
+
+// Start and end block numbers to use when scanning for events
+export interface ScanOverrides {
+  startBlock?: number | string;
+  endBlock?: number | string;
+}
+
+// Type definition for Announcement events emitted from the contract
 export interface Announcement {
   receiver: string;
   amount: BigNumber;
@@ -28,14 +39,17 @@ export interface Announcement {
   ciphertext: string;
 }
 
-// A UserAnnouncementEvent is an Announcement event from Umbra where the recipient is the specified user
-export interface UserAnnouncementEvent {
+// A UserAnnouncement is an Announcement event from Umbra where the recipient is the specified user
+export interface UserAnnouncement {
   event: Event;
   randomNumber: string;
   receiver: string;
   amount: BigNumber;
   token: string;
-  blockNumber: number;
-  timestamp: number;
-  sender: string;
 }
+
+// ======================================= ENS-related types =======================================
+export type EnsNamehash = {
+  hash: (name: string) => string;
+  normalize: (name: string) => string;
+};


### PR DESCRIPTION
Closes #80

Defines new type `ChainConfig` that can be provided when creating an instance of the Umbra class. This defines the Umbra contract address and default block to start scanning from. Umbra instances can now be created with the following options:
- Instantiation: (1) `Umbra.create` with a signer to allow calling methods, or (2) `Umbra.createReadonly` with an node URL to only allow reads
- Chain config: (1)  Don't provide a `chainConfig` to infer it from the signer/provider, or (2) provide a chain ID to use the hardcoded info, or (3) enable it to be fully custom

This results in 3 * 2 = 6 possible ways to create an Umbra class

Other notes:
- The Umbra tests now fetch the latest Ropsten block number and always start scanning from there, so you no longer need to manually update that for tests
- I also made a small update to the `scan` method to allow the start and end block numbers to be overridden.
- All tests should pass, with the exception of the 4 failing ones described in #78 
