### PR TITLE
Pin @unstoppabledomains/resolution to v1.9.0

### DIFF
--- a/umbra-js/package.json
+++ b/umbra-js/package.json
@@ -21,7 +21,7 @@
   "author": "Matt Solomon <matt@mattsolomon.dev>, Ben DiFrancesco <ben@scopelift.co>",
   "license": "ISC",
   "dependencies": {
-    "@unstoppabledomains/resolution": "^1.16.0",
+    "@unstoppabledomains/resolution": "1.9.0",
     "bn.js": "^5.1.3",
     "buffer": "^6.0.2",
     "dotenv": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3769,10 +3769,10 @@
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-"@unstoppabledomains/resolution@^1.16.0":
-  version "1.16.2"
-  resolved "https://registry.yarnpkg.com/@unstoppabledomains/resolution/-/resolution-1.16.2.tgz#b69f75b542c521dc3647d6e74e2b98b38b2536dc"
-  integrity sha512-5+wiAwCGEiHK38gP7JRxOqAhLNj4sx58dl5gyVANGK85SrcUShL3WP5OWcS4JRFeKNNgv96oaxYFy61G/9dmgQ==
+"@unstoppabledomains/resolution@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@unstoppabledomains/resolution/-/resolution-1.9.0.tgz#a6089ecfff915185a365d338f1105b9b7ab5c05d"
+  integrity sha512-vmJk+lAlcL45WoEjqpRgtFSUGrgDy8UwWcKWmmsnkc/2mZF8YhgWJraBwAVPVubQlpF6hV0WKqWiwMmXA+aH1A==
   dependencies:
     "@ensdomains/address-encoder" "0.1.8"
     "@ethersproject/abi" "^5.0.1"


### PR DESCRIPTION
Closes #78

Breaking changes were introduced after this in v1.10.1, so we pin the version to ensure a compatible version is always installed. See the links below for more information:
- https://github.com/unstoppabledomains/resolution/issues/112
- https://github.com/unstoppabledomains/resolution/blob/master/CHANGELOG.md

To test:
1. Update the `startBlock` values in `Umbra.ts` with the latest Ropsten block number
2. Install packages at the root with `yarn`,
3. Run `cd umbra-js` and `yarn test`. All tests should pass with 2 that have always been skipped.