### PR TITLE
Add umbrajs withdraw methods

### DIFF
--- a/umbra-js/src/types.ts
+++ b/umbra-js/src/types.ts
@@ -5,6 +5,7 @@ import { JsonRpcProvider, Web3Provider } from '@ethersproject/providers';
 
 // ========================================= Ethers types ==========================================
 export { SignatureLike } from '@ethersproject/bytes';
+export { TransactionResponse } from '@ethersproject/providers';
 
 export type ExternalProvider =
   | ethers.providers.ExternalProvider
@@ -19,12 +20,12 @@ export interface ChainConfig {
   startBlock: number; // block Umbra contract was deployed at
 }
 
-// Overrides when sending or withdrawing funds
-export interface UmbraOverrides extends Overrides {
+// Overrides when sending funds
+export interface SendOverrides extends Overrides {
   payloadExtension?: string;
 }
 
-// Start and end block numbers to use when scanning for events
+// Overrides for the start and end block numbers to use when scanning for events
 export interface ScanOverrides {
   startBlock?: number | string;
   endBlock?: number | string;

--- a/umbra-js/test/Umbra.test.ts
+++ b/umbra-js/test/Umbra.test.ts
@@ -83,8 +83,6 @@ describe('Umbra class', () => {
     // looping through the accounts above doesn't
     sender['wallet'] = wallets[signerIndex - 1];
     receiver['wallet'] = wallets[receiverIndex - 1];
-    console.log('sender:   ', sender.wallet.address);
-    console.log('receiver: ', receiver.wallet.address);
   });
 
   beforeEach(async () => {

--- a/umbra-js/test/Umbra.test.ts
+++ b/umbra-js/test/Umbra.test.ts
@@ -1,4 +1,3 @@
-import { KeyPair } from '../src/classes/KeyPair';
 import { Umbra } from '../src/classes/Umbra';
 import { BigNumber, BigNumberish, ethers } from 'ethers';
 import { Web3Provider, JsonRpcSigner, JsonRpcProvider } from '@ethersproject/providers';
@@ -211,8 +210,10 @@ describe.only('Umbra class', () => {
 
       // RECEIVER
       // Receiver scans for funds send to them
-      const receiverKeyPair = new KeyPair(receiver.wallet.privateKey);
-      const { userAnnouncements } = await umbra.scan(receiverKeyPair);
+      const { userAnnouncements } = await umbra.scan(
+        receiver.wallet.publicKey,
+        receiver.wallet.privateKey
+      );
       expect(userAnnouncements.length).to.be.greaterThan(0);
 
       // Withdraw
@@ -237,8 +238,10 @@ describe.only('Umbra class', () => {
 
       // RECEIVER
       // Receiver scans for funds send to them
-      const receiverKeyPair = new KeyPair(receiver.wallet.privateKey);
-      const { userAnnouncements } = await umbra.scan(receiverKeyPair);
+      const { userAnnouncements } = await umbra.scan(
+        receiver.wallet.publicKey,
+        receiver.wallet.privateKey
+      );
       expect(userAnnouncements.length).to.be.greaterThan(0);
 
       // Withdraw
@@ -260,19 +263,21 @@ describe.only('Umbra class', () => {
 
       // RECEIVER
       // Receiver scans for funds send to them
-      const receiverKeyPair = new KeyPair(receiver.wallet.privateKey);
-      const { userAnnouncements } = await umbra.scan(receiverKeyPair);
+      const { userAnnouncements } = await umbra.scan(
+        receiver.wallet.publicKey,
+        receiver.wallet.privateKey
+      );
       expect(userAnnouncements.length).to.be.greaterThan(0);
 
       // Withdraw
       // Destination wallet should have a balance equal to amount sent minus gas cost
-      const stealthWallet = Umbra.getStealthWallet(
-        receiverKeyPair,
+      const stealthPrivateKey = Umbra.getStealthPrivateKey(
+        receiver.wallet.privateKey,
         userAnnouncements[0].randomNumber
       );
       const destinationWallet = ethers.Wallet.createRandom();
       const withdrawTx = await umbra.withdraw(
-        stealthWallet,
+        stealthPrivateKey,
         'ETH',
         stealthKeyPair.address,
         destinationWallet.address
@@ -297,8 +302,10 @@ describe.only('Umbra class', () => {
 
       // RECEIVER
       // Receiver scans for funds send to them
-      const receiverKeyPair = new KeyPair(receiver.wallet.privateKey);
-      const { userAnnouncements } = await umbra.scan(receiverKeyPair);
+      const { userAnnouncements } = await umbra.scan(
+        receiver.wallet.publicKey,
+        receiver.wallet.privateKey
+      );
       expect(userAnnouncements.length).to.be.greaterThan(0);
 
       // Withdraw

--- a/umbra-js/test/Umbra.test.ts
+++ b/umbra-js/test/Umbra.test.ts
@@ -1,21 +1,27 @@
 import { KeyPair } from '../src/classes/KeyPair';
 import { Umbra } from '../src/classes/Umbra';
-import { ethers } from 'ethers';
-import { Web3Provider } from '@ethersproject/providers';
+import { BigNumber, BigNumberish, ethers } from 'ethers';
+import { Web3Provider, JsonRpcSigner, JsonRpcProvider } from '@ethersproject/providers';
 import * as chai from 'chai';
 import { accounts, provider } from '@openzeppelin/test-environment';
 import type { ChainConfig, ExternalProvider } from '../src/types';
-import { TestToken as ERC20, TestToken__factory as ERC20__factory } from '../types/contracts';
+import {
+  TestToken as ERC20,
+  Umbra as UmbraContract,
+  TestToken__factory as ERC20__factory,
+  Umbra__factory,
+} from '../types/contracts';
 import { node } from '../test-environment.config';
 
 const { expect } = chai;
 const web3Provider = (provider as unknown) as ExternalProvider;
 const ethersProvider = new Web3Provider(web3Provider);
-
 const JSON_RPC_URL = node.fork;
+const jsonRpcProvider = new JsonRpcProvider(JSON_RPC_URL);
+
 const ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 const payloadExtension = '0x0123456789abcdef0123456789abcdef';
-const quantity = ethers.utils.parseEther('10');
+const quantity = ethers.utils.parseEther('5');
 
 /**
  * @notice Wrapper function to verify that an async function rejects with the specified message
@@ -45,13 +51,20 @@ type TestSigner = {
   signer: ethers.providers.JsonRpcSigner;
 };
 
-describe('Umbra class', () => {
+describe.only('Umbra class', () => {
   let sender = {} as TestSigner;
   let receiver = {} as TestSigner;
 
   let dai: ERC20;
   let umbra: Umbra;
-  let umbraReadonly: Umbra;
+  let chainConfig: ChainConfig;
+
+  const getEthBalance = async (address: string) => {
+    return (await ethersProvider.getBalance(address)).toString();
+  };
+  const verifyEqualValues = (val1: BigNumberish, val2: BigNumberish) => {
+    expect(BigNumber.from(val1).toString()).to.equal(BigNumber.from(val2).toString());
+  };
 
   before(() => {
     // Load private keys of ganache accounts
@@ -69,66 +82,84 @@ describe('Umbra class', () => {
     // looping through the accounts above doesn't
     sender['wallet'] = wallets[signerIndex - 1];
     receiver['wallet'] = wallets[receiverIndex - 1];
+    console.log('sender:   ', sender.wallet.address);
+    console.log('receiver: ', receiver.wallet.address);
   });
 
   beforeEach(async () => {
     // Get signers (can't use wallets since they need providers)
-    const ethersProvider = new ethers.providers.Web3Provider(web3Provider);
     sender.signer = ethersProvider.getSigner(signerIndex);
-    // const receiver.signer = ethersProvider.getSigner(receiverIndex);
+    receiver.signer = ethersProvider.getSigner(receiverIndex);
 
-    // Get chainConfig based on most recent Ropsten block number to minimize scanning time
-    const lastBlockNumber = await ethersProvider.getBlockNumber();
-    const chainConfig: ChainConfig = {
-      umbraAddress: '0x3bB03be8dAB8969b16684D360eD2C7Aa47dC36f0',
-      startBlock: lastBlockNumber,
-    };
-
-    // Get Umbra instances
-    umbra = await Umbra.create(sender.signer, chainConfig);
-    umbraReadonly = await Umbra.createReadonly(JSON_RPC_URL, chainConfig);
+    // Deploy Umbra
+    const toll = ethers.utils.parseEther('0.1');
+    const tollCollector = ethers.constants.AddressZero; // doesn't matter for these tests
+    const tollReceiver = ethers.constants.AddressZero; // doesn't matter for these tests
+    const umbraFactory = new Umbra__factory(sender.signer);
+    const umbraContract = (await umbraFactory.deploy(
+      toll,
+      tollCollector,
+      tollReceiver
+    )) as UmbraContract;
+    await umbraContract.deployTransaction.wait();
 
     // Deploy mock tokens
     const daiFactory = new ERC20__factory(sender.signer);
     dai = (await daiFactory.deploy('Dai', 'DAI')) as ERC20;
     await dai.deployTransaction.wait();
+
+    // Get chainConfig based on most recent Ropsten block number to minimize scanning time
+    const lastBlockNumber = await ethersProvider.getBlockNumber();
+    chainConfig = {
+      umbraAddress: umbraContract.address,
+      startBlock: lastBlockNumber,
+    };
+
+    // Get Umbra instance
+    umbra = new Umbra(ethersProvider, chainConfig);
+    // umbra = await Umbra.create(sender.signer, chainConfig);
+    // umbraReadonly = await Umbra.createReadonly(JSON_RPC_URL, chainConfig);
   });
 
   describe('Initialization', () => {
-    it('initializes correctly when using a web3 provider', async () => {
-      expect(umbra.provider._isProvider).to.be.true;
-      expect(Boolean(umbra.signer)).to.be.true;
+    it('initializes correctly when passing a chain config', async () => {
+      // URL provider
+      const umbra1 = new Umbra(jsonRpcProvider, chainConfig);
+      expect(umbra1.provider._isProvider).to.be.true;
+      expect(umbra1.chainConfig.umbraAddress).to.equal(chainConfig.umbraAddress);
+      expect(umbra1.chainConfig.startBlock).to.equal(chainConfig.startBlock);
+
+      // Web3 provider
+      const umbra2 = new Umbra(ethersProvider, chainConfig);
+      expect(umbra2.provider._isProvider).to.be.true;
+      expect(umbra2.chainConfig.umbraAddress).to.equal(chainConfig.umbraAddress);
+      expect(umbra2.chainConfig.startBlock).to.equal(chainConfig.startBlock);
     });
 
-    it('initializes correctly when using a JSON-RPC provider', async () => {
-      expect(umbraReadonly.provider._isProvider).to.be.true;
-      expect(Boolean(umbraReadonly.signer)).to.be.false;
-    });
-
-    it('initializes correctly when using a default chainId', async () => {
-      // Localhost with signer
-      const umbra1 = await Umbra.create(sender.signer, 1337);
+    it('initializes correctly when passing a default chainId', async () => {
+      // Localhost with URL provider
+      const umbra1 = new Umbra(jsonRpcProvider, 1337);
       expect(umbra1.chainConfig.umbraAddress).to.equal(
         '0x3bB03be8dAB8969b16684D360eD2C7Aa47dC36f0'
       );
       expect(umbra1.chainConfig.startBlock).to.equal(9496718);
 
-      // Localhost with read-only provider
-      const umbra2 = await Umbra.createReadonly(JSON_RPC_URL, 1337);
+      // Localhost with Web3 provider
+      const umbra2 = new Umbra(ethersProvider, 1337);
       expect(umbra2.chainConfig.umbraAddress).to.equal(
         '0x3bB03be8dAB8969b16684D360eD2C7Aa47dC36f0'
       );
       expect(umbra2.chainConfig.startBlock).to.equal(9496718);
 
-      // Ropsten with signer
-      const umbra3 = await Umbra.create(sender.signer, 3);
+      // Ropsten with URL provider
+      const umbra3 = new Umbra(jsonRpcProvider, 3);
       expect(umbra3.chainConfig.umbraAddress).to.equal(
         '0x3bB03be8dAB8969b16684D360eD2C7Aa47dC36f0'
       );
       expect(umbra3.chainConfig.startBlock).to.equal(9496718);
 
-      // Ropsten with read-only provider
-      const umbra4 = await Umbra.createReadonly(JSON_RPC_URL, 3);
+      // Ropsten with Web3 provider
+      const umbra4 = new Umbra(jsonRpcProvider, 3);
       expect(umbra4.chainConfig.umbraAddress).to.equal(
         '0x3bB03be8dAB8969b16684D360eD2C7Aa47dC36f0'
       );
@@ -137,30 +168,25 @@ describe('Umbra class', () => {
 
     it('does not allow invalid default chain IDs to be provided', async () => {
       const msg = 'Unsupported chain ID provided';
-      await expectRejection(Umbra.create(sender.signer, 999), msg);
-      await expectRejection(Umbra.createReadonly(JSON_RPC_URL, 999), msg);
-    });
-
-    it('initializes correctly when using a custom chain configuration', async () => {
-      // Define random properties since they are not verified
-      const chainConfig = { umbraAddress: ethers.constants.AddressZero, startBlock: 100 };
-
-      // Custom chain config with signer
-      const umbra1 = await Umbra.create(sender.signer, chainConfig);
-      expect(umbra1.chainConfig.umbraAddress).to.equal(chainConfig.umbraAddress);
-      expect(umbra1.chainConfig.startBlock).to.equal(chainConfig.startBlock);
-
-      // Custom chain config with read-only provider
-      const umbra2 = await Umbra.createReadonly(JSON_RPC_URL, chainConfig);
-      expect(umbra2.chainConfig.umbraAddress).to.equal(chainConfig.umbraAddress);
-      expect(umbra2.chainConfig.startBlock).to.equal(chainConfig.startBlock);
+      const constructor1 = () => new Umbra(jsonRpcProvider, 999);
+      const constructor2 = () => new Umbra(ethersProvider, 999);
+      expect(constructor1).to.throw(msg);
+      expect(constructor2).to.throw(msg);
     });
   });
 
-  describe('Sends funds', () => {
+  describe('Send, scan, and withdraw funds', () => {
+    const mintAndApproveDai = async (signer: JsonRpcSigner, user: string, amount: BigNumber) => {
+      await dai.connect(signer).mint(user, amount);
+      await dai.connect(signer).approve(umbra.umbraContract.address, ethers.constants.MaxUint256);
+    };
+
     it('reverts if sender does not have enough tokens', async () => {
       const msg = `Insufficient balance to complete transfer. Has 0 tokens, tried to send ${quantity.toString()} tokens.`;
-      await expectRejection(umbra.send(dai.address, quantity, receiver.wallet!.address), msg);
+      await expectRejection(
+        umbra.send(sender.signer, dai.address, quantity, receiver.wallet!.address),
+        msg
+      );
     });
 
     it('reverts if sender does not have enough ETH', async () => {
@@ -172,13 +198,11 @@ describe('Umbra class', () => {
     it('Without payload extension: send tokens, scan for them, withdraw them', async () => {
       // SENDER
       // Mint Dai to sender, and approve the Umbra contract to spend their DAI
-      await dai.connect(sender.signer).mint(sender.wallet.address, quantity);
-      await dai
-        .connect(sender.signer)
-        .approve(umbra.umbraContract.address, ethers.constants.MaxUint256);
+      await mintAndApproveDai(sender.signer, sender.wallet.address, quantity);
 
       // Send funds with Umbra
       const { tx, stealthKeyPair } = await umbra.send(
+        sender.signer,
         dai.address,
         quantity,
         receiver.wallet!.publicKey
@@ -199,13 +223,11 @@ describe('Umbra class', () => {
     it('With payload extension: send tokens, scan for them, withdraw them', async () => {
       // SENDER
       // Mint Dai to sender, and approve the Umbra contract to spend their DAI
-      await dai.connect(sender.signer).mint(sender.wallet.address, quantity);
-      await dai
-        .connect(sender.signer)
-        .approve(umbra.umbraContract.address, ethers.constants.MaxUint256);
+      await mintAndApproveDai(sender.signer, sender.wallet.address, quantity);
 
       // Send funds with Umbra
       const { tx, stealthKeyPair } = await umbra.send(
+        sender.signer,
         dai.address,
         quantity,
         receiver.wallet!.publicKey,
@@ -228,11 +250,13 @@ describe('Umbra class', () => {
       // SENDER
       // Send funds with Umbra
       const { tx, stealthKeyPair } = await umbra.send(
+        sender.signer,
         ETH_ADDRESS,
         quantity,
         receiver.wallet!.publicKey
       );
       await tx.wait();
+      verifyEqualValues(await getEthBalance(stealthKeyPair.address), quantity);
 
       // RECEIVER
       // Receiver scans for funds send to them
@@ -241,14 +265,29 @@ describe('Umbra class', () => {
       expect(userAnnouncements.length).to.be.greaterThan(0);
 
       // Withdraw
-      // TODO once meta-transaction implementation is done + contract redeployed
-      stealthKeyPair; // silence unused error -- we'll use this to verify receipt/withdrawals later
+      // Destination wallet should have a balance equal to amount sent minus gas cost
+      const stealthWallet = Umbra.getStealthWallet(
+        receiverKeyPair,
+        userAnnouncements[0].randomNumber
+      );
+      const destinationWallet = ethers.Wallet.createRandom();
+      const withdrawTx = await umbra.withdraw(
+        stealthWallet,
+        'ETH',
+        stealthKeyPair.address,
+        destinationWallet.address
+      );
+      await withdrawTx.wait();
+      const txCost = withdrawTx.gasLimit.mul(withdrawTx.gasPrice);
+      verifyEqualValues(await getEthBalance(destinationWallet.address), quantity.sub(txCost));
+      verifyEqualValues(await getEthBalance(stealthKeyPair.address), 0);
     });
 
     it('With payload extension: send ETH, scan for it, withdraw it', async () => {
       // SENDER
       // Send funds with Umbra
       const { tx, stealthKeyPair } = await umbra.send(
+        sender.signer,
         ETH_ADDRESS,
         quantity,
         receiver.wallet!.publicKey,


### PR DESCRIPTION
Closes #79 

Also refactors methods to take in exactly what is needed. So we no longer associate keys or a signer with the Umbra class—just a provider—and methods take keys or singers as inputs when needed