### PR TITLE
Stricter input validation in umbra-js, other cleanup/ehancements

### DIFF
--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -220,7 +220,6 @@ function useReceivedFundsTable(announcements: UserAnnouncement[]) {
         tx = await umbra.value.withdraw(
           spendingPrivateKey,
           token.address,
-          announcement.receiver,
           destinationAddress.value
         );
       } else {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,10 @@
 {
-    "files": [],
-    "references": [{ "path": "frontend" }, { "path": "umbra-js" }, { "path": "contracts" }],
-    "exclude": ["node_modules"]
+  "files": [],
+  "references": [
+    { "path": "frontend" },
+    { "path": "umbra-js" },
+    { "path": "contracts" }
+  ],
+  "exclude": ["node_modules"],
+  "typeRoots": ["./node_modules/@types"]
 }

--- a/umbra-js/package.json
+++ b/umbra-js/package.json
@@ -25,7 +25,7 @@
     "bn.js": "^5.1.3",
     "buffer": "^6.0.2",
     "dotenv": "^8.2.0",
-    "elliptic": "^6.5.2",
+    "elliptic": "^6.5.4",
     "eth-ens-namehash": "^2.0.8",
     "ethers": "^5.0.25",
     "js-sha3": "^0.8.0"

--- a/umbra-js/src/classes/DomainService.ts
+++ b/umbra-js/src/classes/DomainService.ts
@@ -33,7 +33,7 @@ export class DomainService {
    * @param name domain, e.g. myname.eth
    */
   namehash(name: string) {
-    if (DomainService.isEnsDomain(name)) {
+    if (ens.isEnsDomain(name)) {
       return ens.namehash(name);
     } else {
       return cns.namehash(name, this.udResolution);
@@ -45,7 +45,7 @@ export class DomainService {
    * @param name domain, e.g. myname.eth
    */
   async getPublicKeys(name: string) {
-    if (DomainService.isEnsDomain(name)) {
+    if (ens.isEnsDomain(name)) {
       return ens.getPublicKeys(name, this.provider);
     } else {
       return cns.getPublicKeys(name, this.udResolution);
@@ -59,32 +59,10 @@ export class DomainService {
    * @returns Transaction hash
    */
   async setPublicKeys(name: string, spendingPrivateKey: string, viewingPrivateKey: string) {
-    if (DomainService.isEnsDomain(name)) {
+    if (ens.isEnsDomain(name)) {
       return ens.setPublicKeys(name, spendingPrivateKey, viewingPrivateKey, this.provider);
     } else {
       return cns.setPublicKeys(name, this.provider, this.udResolution, spendingPrivateKey);
     }
-  }
-
-  /**
-   * @notice Returns supported ENS domains
-   * @dev Defined as a static method to simplify access to this data
-   */
-  static supportedEnsDomains() {
-    return ['.eth', '.xyz', '.kred', '.luxe', '.club', '.art'];
-  }
-
-  /**
-   * @notice Returns true if the provided name is an ENS domain, false otherwise
-   * @dev Defined as a static method to simplify access to this method
-   * @param domainName Name to check
-   */
-  static isEnsDomain(domainName: string) {
-    for (const suffix of DomainService.supportedEnsDomains()) {
-      if (domainName.endsWith(suffix)) {
-        return true;
-      }
-    }
-    return false;
   }
 }

--- a/umbra-js/src/classes/DomainService.ts
+++ b/umbra-js/src/classes/DomainService.ts
@@ -33,7 +33,7 @@ export class DomainService {
    * @param name domain, e.g. myname.eth
    */
   namehash(name: string) {
-    if (isEnsDomain(name)) {
+    if (DomainService.isEnsDomain(name)) {
       return ens.namehash(name);
     } else {
       return cns.namehash(name, this.udResolution);
@@ -45,7 +45,7 @@ export class DomainService {
    * @param name domain, e.g. myname.eth
    */
   async getPublicKeys(name: string) {
-    if (isEnsDomain(name)) {
+    if (DomainService.isEnsDomain(name)) {
       return ens.getPublicKeys(name, this.provider);
     } else {
       return cns.getPublicKeys(name, this.udResolution);
@@ -59,14 +59,32 @@ export class DomainService {
    * @returns Transaction hash
    */
   async setPublicKeys(name: string, spendingPrivateKey: string, viewingPrivateKey: string) {
-    if (isEnsDomain(name)) {
+    if (DomainService.isEnsDomain(name)) {
       return ens.setPublicKeys(name, spendingPrivateKey, viewingPrivateKey, this.provider);
     } else {
       return cns.setPublicKeys(name, this.provider, this.udResolution, spendingPrivateKey);
     }
   }
-}
 
-function isEnsDomain(domainName: string) {
-  return domainName.endsWith('.eth');
+  /**
+   * @notice Returns supported ENS domains
+   * @dev Defined as a static method to simplify access to this data
+   */
+  static supportedEnsDomains() {
+    return ['.eth', '.xyz', '.kred', '.luxe', '.club', '.art'];
+  }
+
+  /**
+   * @notice Returns true if the provided name is an ENS domain, false otherwise
+   * @dev Defined as a static method to simplify access to this method
+   * @param domainName Name to check
+   */
+  static isEnsDomain(domainName: string) {
+    for (const suffix of DomainService.supportedEnsDomains()) {
+      if (domainName.endsWith(suffix)) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/umbra-js/src/classes/RandomNumber.ts
+++ b/umbra-js/src/classes/RandomNumber.ts
@@ -21,19 +21,17 @@ export class RandomNumber {
    * hex string where the first two characters are 0x
    */
   constructor(readonly payloadExtension: string = zeroPrefix) {
+    // Validate it payload extension
+    if (!isHexString(payloadExtension)) {
+      throw new Error('Payload extension is not a valid hex string');
+    }
+    if (payloadExtension.length !== 34) {
+      throw new Error('Payload extension must be a 16 byte hex string with the 0x prefix');
+    }
+
     // Generate default random number without payload extension
     const randomNumberAsBytes = randomBytes(this.randomLength);
     this.value = BigNumber.from(randomNumberAsBytes);
-
-    // If a payload extension was provided, validate it
-    if (payloadExtension !== zeroPrefix) {
-      if (!isHexString(payloadExtension)) {
-        throw new Error('Payload extension is not a valid hex string');
-      }
-      if (payloadExtension.length !== 34) {
-        throw new Error('Payload extension must be a 16 byte hex string with the 0x prefix');
-      }
-    }
 
     // Payload extension is valid, so update the random number. If no payload extension is provided
     // the below is equivalent doing nothing, as it replaces the zero prefix with the zero prefix

--- a/umbra-js/src/types.ts
+++ b/umbra-js/src/types.ts
@@ -24,6 +24,12 @@ export interface ChainConfig {
   startBlock: number; // block Umbra contract was deployed at
 }
 
+// Used for passing around encrypted random number
+export interface EncryptedPayload {
+  ephemeralPublicKey: string; // hex string with 0x04 prefix
+  ciphertext: string; // hex string with 0x prefix
+}
+
 // Type for storing compressed public keys
 export interface CompressedPublicKey {
   prefix: number;

--- a/umbra-js/src/utils/ens.ts
+++ b/umbra-js/src/utils/ens.ts
@@ -17,6 +17,10 @@ type StealthKeys = {
   viewingPubKey: BigNumber;
 };
 
+/**
+ * @notice Returns the address of the ENS resolver to use based on the provider's network
+ * @param provider Provider to fetch ENS resolver address for
+ */
 const getEnsResolverAddress = async (provider: EthersProvider) => {
   const chainId = (await provider.getNetwork()).chainId;
   if (chainId === 4 || chainId === 1337) {
@@ -26,10 +30,34 @@ const getEnsResolverAddress = async (provider: EthersProvider) => {
 };
 
 /**
+ * @notice Returns supported ENS domain endings
+ */
+export const supportedEnsDomains = ['.eth', '.xyz', '.kred', '.luxe', '.club', '.art'];
+
+/**
+ * @notice Returns true if the provided name is an ENS domain, false otherwise
+ * @param domainName Name to check
+ */
+export function isEnsDomain(domainName: string) {
+  for (const suffix of supportedEnsDomains) {
+    if (domainName.endsWith(suffix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * @notice Computes ENS namehash of the input ENS domain, normalized to ENS compatibility
  * @param name ENS domain, e.g. myname.eth
  */
 export function namehash(name: string) {
+  if (typeof name !== 'string') {
+    throw new Error('Name must be a string with a supported suffix');
+  }
+  if (!isEnsDomain(name)) {
+    throw new Error(`Name does not end with supported suffix: ${supportedEnsDomains.join(', ')}`);
+  }
   return ensNamehash.hash(ensNamehash.normalize(name));
 }
 

--- a/umbra-js/test/DomainService.test.ts
+++ b/umbra-js/test/DomainService.test.ts
@@ -35,13 +35,6 @@ describe('DomainService class', () => {
       expect(hash).to.equal('0xbe0b801f52a20451e2845cf346b7c8de65f4beca0ebba17c14ce601de7bbc7fb');
     });
 
-    it('properly identifies ENS domains', async () => {
-      DomainService.supportedEnsDomains().forEach((suffix) => {
-        // example suffixes: .eth, .xyz, etc.
-        expect(DomainService.isEnsDomain(`test${suffix}`)).to.be.true;
-      });
-    });
-
     it.skip('sets the public keys for an ENS address', async function () {
       this.timeout(10000);
       // TODO

--- a/umbra-js/test/DomainService.test.ts
+++ b/umbra-js/test/DomainService.test.ts
@@ -35,6 +35,13 @@ describe('DomainService class', () => {
       expect(hash).to.equal('0xbe0b801f52a20451e2845cf346b7c8de65f4beca0ebba17c14ce601de7bbc7fb');
     });
 
+    it('properly identifies ENS domains', async () => {
+      DomainService.supportedEnsDomains().forEach((suffix) => {
+        // example suffixes: .eth, .xyz, etc.
+        expect(DomainService.isEnsDomain(`test${suffix}`)).to.be.true;
+      });
+    });
+
     it.skip('sets the public keys for an ENS address', async function () {
       this.timeout(10000);
       // TODO

--- a/umbra-js/test/KeyPair.test.ts
+++ b/umbra-js/test/KeyPair.test.ts
@@ -33,6 +33,26 @@ const generateRandomNumber = (payloadExtension: string | undefined = undefined) 
   return new RandomNumber(randomPayloadExtension);
 };
 
+/**
+ * @notice Wrapper function to verify that an async function rejects with the specified message
+ * @param promise Promise to wait for
+ * @param message Expected rejection message
+ */
+const expectRejection = async (promise: Promise<any>, message: string) => {
+  // Error type requires strings, so we set them to an arbitrary value and
+  // later check the values. If unchanged, the promise did not reject
+  let error: Error = { name: 'default', message: 'default' };
+  try {
+    await promise;
+  } catch (e) {
+    error = e;
+  } finally {
+    expect(error.name).to.not.equal('default');
+    expect(error.message).to.not.equal('default');
+    expect(error.message).to.equal(message);
+  }
+};
+
 describe('KeyPair class', () => {
   let wallet: Wallet;
 
@@ -40,255 +60,325 @@ describe('KeyPair class', () => {
     wallet = Wallet.createRandom();
   });
 
-  it('should not initialize an instance without the 0x prefix', () => {
-    expect(() => new KeyPair(privateKey.slice(2))).to.throw('Key must be in hex format with 0x prefix');
-    expect(() => new KeyPair(wallet.publicKey.slice(4))).to.throw('Key must be in hex format with 0x prefix');
+  describe('Initialization', () => {
+    it('initializes an instance with valid private key', () => {
+      // Check against ganache account
+      const keyPair = new KeyPair(privateKey);
+      expect(keyPair.address).to.equal(address);
+      // Check against random wallet
+      const keyPair2 = new KeyPair(wallet.privateKey);
+      expect(keyPair2.address).to.equal(wallet.address);
+    });
+
+    it('initializes an instance with valid public key', () => {
+      const keyPair = new KeyPair(wallet.publicKey);
+      expect(keyPair.address).to.equal(wallet.address);
+    });
+
+    it('initializes an instance from a regular transaction', async () => {
+      // Specify rinkeby transaction hash and its sender
+      const txHash = '0x0f18ca5d71b4ad595a7a9a649c940aeec068ef6f1a4fe71f210578a8ea483e0f';
+      const from = '0x40f3F89639bFFc7B23cA5D9FCB9eD9a9C579664B';
+      // Create instance and check result
+      const keyPair = await KeyPair.instanceFromTransaction(txHash, ethersProvider);
+      expect(keyPair.address).to.equal(from);
+    });
+
+    it('initializes an instance from a contract interaction transaction', async () => {
+      // Specify rinkeby transaction hash and its sender
+      const txHash = '0xfc84305e8aea7c735bd89e01e0fe66b50ce8ed8c940291fa8f3e1a1070f029c5';
+      const from = '0x72378CbC246C17fe856d7678d944a0C51227eD59';
+      // Create instance and check result
+      const keyPair = await KeyPair.instanceFromTransaction(txHash, ethersProvider);
+      expect(keyPair.address).to.equal(from);
+    });
+
+    it('initializes an instance from a contract creation transaction', async () => {
+      // Specify rinkeby transaction hash and its sender
+      const txHash = '0xa84eae9a81444a02d10916627c282fe16fd78eb8ed3e2bd36ec257f7272ddcd0';
+      const from = '0x627306090abaB3A6e1400e9345bC60c78a8BEf57';
+      // Create instance and check result
+      const keyPair = await KeyPair.instanceFromTransaction(txHash, ethersProvider);
+      expect(keyPair.address).to.equal(from);
+    });
   });
 
-  it('initializes an instance with valid private key', () => {
-    // Check against ganache account
-    const keyPair = new KeyPair(privateKey);
-    expect(keyPair.address).to.equal(address);
-    // Check against random wallet
-    const keyPair2 = new KeyPair(wallet.privateKey);
-    expect(keyPair2.address).to.equal(wallet.address);
-  });
+  describe('Functionality', () => {
+    it('will recover the public key from an arbitrary transaction', async () => {
+      // Specify rinkeby transaction hash and its sender
+      const txHash = '0x0f18ca5d71b4ad595a7a9a649c940aeec068ef6f1a4fe71f210578a8ea483e0f';
+      const sendersPublicKey =
+        '0x041e2f66297fe2f58c9a9e4b7895bd4e5107581ed533ea9ff311631ea15692a6e6eb8d38f1bddf2e6e9f00dc5120e313671c93570b4997dcd9cd9388ae35ffd4b8';
+      // Create instance and check result
+      const recoveredPublicKey = await utils.recoverPublicKeyFromTransaction(txHash, ethersProvider);
+      expect(recoveredPublicKey).to.equal(sendersPublicKey);
+    });
 
-  it('initializes an instance with valid public key', () => {
-    const keyPair = new KeyPair(wallet.publicKey);
-    expect(keyPair.address).to.equal(wallet.address);
-  });
-
-  it('initializes an instance from a regular transaction', async () => {
-    // Specify rinkeby transaction hash and its sender
-    const txHash = '0x0f18ca5d71b4ad595a7a9a649c940aeec068ef6f1a4fe71f210578a8ea483e0f';
-    const from = '0x40f3F89639bFFc7B23cA5D9FCB9eD9a9C579664B';
-    // Create instance and check result
-    const keyPair = await KeyPair.instanceFromTransaction(txHash, ethersProvider);
-    expect(keyPair.address).to.equal(from);
-  });
-
-  it('initializes an instance from a contract interaction transaction', async () => {
-    // Specify rinkeby transaction hash and its sender
-    const txHash = '0xfc84305e8aea7c735bd89e01e0fe66b50ce8ed8c940291fa8f3e1a1070f029c5';
-    const from = '0x72378CbC246C17fe856d7678d944a0C51227eD59';
-    // Create instance and check result
-    const keyPair = await KeyPair.instanceFromTransaction(txHash, ethersProvider);
-    expect(keyPair.address).to.equal(from);
-  });
-
-  it('initializes an instance from a contract creation transaction', async () => {
-    // Specify rinkeby transaction hash and its sender
-    const txHash = '0xa84eae9a81444a02d10916627c282fe16fd78eb8ed3e2bd36ec257f7272ddcd0';
-    const from = '0x627306090abaB3A6e1400e9345bC60c78a8BEf57';
-    // Create instance and check result
-    const keyPair = await KeyPair.instanceFromTransaction(txHash, ethersProvider);
-    expect(keyPair.address).to.equal(from);
-  });
-
-  it('will recover the public key from an arbitrary transaction', async () => {
-    // Specify rinkeby transaction hash and its sender
-    const txHash = '0x0f18ca5d71b4ad595a7a9a649c940aeec068ef6f1a4fe71f210578a8ea483e0f';
-    const sendersPublicKey =
-      '0x041e2f66297fe2f58c9a9e4b7895bd4e5107581ed533ea9ff311631ea15692a6e6eb8d38f1bddf2e6e9f00dc5120e313671c93570b4997dcd9cd9388ae35ffd4b8';
-    // Create instance and check result
-    const recoveredPublicKey = await utils.recoverPublicKeyFromTransaction(txHash, ethersProvider);
-    expect(recoveredPublicKey).to.equal(sendersPublicKey);
-  });
-
-  it('properly compresses and uncompresses public keys', async () => {
-    // Known set of private keys that fail if compressed public key is not padded to 32 bytes (in
-    // other words, these private keys generate public keys that start with a zero-byte)
-    // prettier-ignore
-    const privateKeys = [ '0x7a79b9a28a51ff8704238959a7b19dd43149698b32065559948419e650636f68', '0xa1275d22f814d1e766d76eeea4f97584a322bec236176d291c3a46856b8d8770', '0xa5e4845e9d1bd6e546ee6655519a4400a9b591afc1fc09c74016a6e17c27c47b', '0x2a618897e58ef3a09a1c3f8b32931bc08fc671e00545b9e919fb418367eec49d', '0xa01d066e7f01d664296fbab225d86590555e762f021f73a6837ab69a4b20fb32', '0xdbe0800f84f57e58f16b346fe8b6c264700a5adbb70bb522bd3ee4b75f3d59c7', '0xed8dee728fb529b9fa1a78e205685e632609c0b43600048323fde68353990be7', ];
-    for (let i = 0; i < privateKeys.length; i += 1) {
-      wallet = new Wallet(privateKeys[i]);
-      const compressedPublicKey = KeyPair.compressPublicKey(wallet.publicKey);
-      const uncompressedPublicKey = KeyPair.getUncompressedFromX(
-        compressedPublicKey.pubKeyXCoordinate,
-        compressedPublicKey.prefix
-      );
-      expect(uncompressedPublicKey).to.equal(wallet.publicKey);
-    }
-
-    // Repeat again but with random private keys
-    for (let i = 0; i < numberOfRuns; i += 1) {
-      wallet = Wallet.createRandom();
-      const compressedPublicKey = KeyPair.compressPublicKey(wallet.publicKey);
-      const uncompressedPublicKey = KeyPair.getUncompressedFromX(
-        compressedPublicKey.pubKeyXCoordinate,
-        compressedPublicKey.prefix
-      );
-      expect(uncompressedPublicKey).to.equal(wallet.publicKey);
-    }
-  });
-
-  it('successfully decrypts random number regardless of ephemeral public key prefix', async () => {
-    for (let i = 0; i < numberOfRuns; i += 1) {
-      // Recipient account setup
-      const recipient = Wallet.createRandom();
-      const umbra = new Umbra(ethersProvider, 4);
-      const { viewingKeyPair } = await umbra.generatePrivateKeys(recipient);
-
-      // Simulate sender encrypting the random number
-      const randomNumber = new RandomNumber();
-      const encrypted = viewingKeyPair.encrypt(randomNumber);
-
-      // Pull out the data that is published to chain and emitted as an event
-      const { ciphertext } = encrypted;
-      const { pubKeyXCoordinate } = KeyPair.compressPublicKey(encrypted.ephemeralPublicKey);
-
-      // Assume 02 prefix and decrypt
-      const uncompressedPubKey1 = KeyPair.getUncompressedFromX(pubKeyXCoordinate, 2);
-      const payload1 = { ephemeralPublicKey: uncompressedPubKey1, ciphertext };
-      const randomNumber1 = viewingKeyPair.decrypt(payload1);
-      expect(randomNumber1).to.equal(randomNumber.asHex);
-
-      // Assume 03 prefix and decrypt
-      const uncompressedPubKey2 = KeyPair.getUncompressedFromX(pubKeyXCoordinate, 3);
-      const payload2 = { ephemeralPublicKey: uncompressedPubKey2, ciphertext };
-      const randomNumber2 = viewingKeyPair.decrypt(payload2);
-      expect(randomNumber2).to.equal(randomNumber.asHex);
-      expect(uncompressedPubKey1).to.not.equal(uncompressedPubKey2); // confirm we took different paths to same result
-    }
-  });
-
-  it('properly derives public key parameters with both key-based constructor methods', () => {
-    const keyPair1 = new KeyPair(wallet.privateKey);
-    const keyPair2 = new KeyPair(wallet.publicKey);
-
-    expect(keyPair1.publicKeyHex).to.equal(keyPair2.publicKeyHex);
-    expect(keyPair1.publicKeyHexSlim).to.equal(keyPair2.publicKeyHexSlim);
-    expect(keyPair1.publicKeyHexCoords.x).to.equal(keyPair2.publicKeyHexCoords.x);
-    expect(keyPair1.publicKeyHexCoords.y).to.equal(keyPair2.publicKeyHexCoords.y);
-    expect(keyPair1.publicKeyBN.toHexString()).to.equal(keyPair2.publicKeyBN.toHexString());
-    expect(JSON.stringify(keyPair1.publicKeyEC)).to.equal(JSON.stringify(keyPair2.publicKeyEC));
-  });
-
-  it('supports encryption and decryption of the random number', async () => {
-    // Do a bunch of tests with random wallets and numbers
-    for (let i = 0; i < numberOfRuns; i += 1) {
-      // Every 100th run, print status update and use the zero payload extension
-      let randomNumber: RandomNumber;
-      if ((i + 1) % 100 === 0) {
-        console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
-        randomNumber = generateRandomNumber(zeroPrefix);
-      } else {
-        randomNumber = generateRandomNumber();
+    it('properly compresses and uncompresses public keys', async () => {
+      // Known set of private keys that fail if compressed public key is not padded to 32 bytes (in
+      // other words, these private keys generate public keys that start with a zero-byte)
+      // prettier-ignore
+      const privateKeys = [ '0x7a79b9a28a51ff8704238959a7b19dd43149698b32065559948419e650636f68', '0xa1275d22f814d1e766d76eeea4f97584a322bec236176d291c3a46856b8d8770', '0xa5e4845e9d1bd6e546ee6655519a4400a9b591afc1fc09c74016a6e17c27c47b', '0x2a618897e58ef3a09a1c3f8b32931bc08fc671e00545b9e919fb418367eec49d', '0xa01d066e7f01d664296fbab225d86590555e762f021f73a6837ab69a4b20fb32', '0xdbe0800f84f57e58f16b346fe8b6c264700a5adbb70bb522bd3ee4b75f3d59c7', '0xed8dee728fb529b9fa1a78e205685e632609c0b43600048323fde68353990be7', ];
+      for (let i = 0; i < privateKeys.length; i += 1) {
+        wallet = new Wallet(privateKeys[i]);
+        const compressedPublicKey = KeyPair.compressPublicKey(wallet.publicKey);
+        const uncompressedPublicKey = KeyPair.getUncompressedFromX(
+          compressedPublicKey.pubKeyXCoordinate,
+          compressedPublicKey.prefix
+        );
+        expect(uncompressedPublicKey).to.equal(wallet.publicKey);
       }
 
-      // Generate random wallet and encrypt payload
+      // Repeat again but with random private keys
+      for (let i = 0; i < numberOfRuns; i += 1) {
+        wallet = Wallet.createRandom();
+        const compressedPublicKey = KeyPair.compressPublicKey(wallet.publicKey);
+        const uncompressedPublicKey = KeyPair.getUncompressedFromX(
+          compressedPublicKey.pubKeyXCoordinate,
+          compressedPublicKey.prefix
+        );
+        expect(uncompressedPublicKey).to.equal(wallet.publicKey);
+      }
+    });
+
+    it('successfully decrypts random number regardless of ephemeral public key prefix', async () => {
+      for (let i = 0; i < numberOfRuns; i += 1) {
+        // Recipient account setup
+        const recipient = Wallet.createRandom();
+        const umbra = new Umbra(ethersProvider, 4);
+        const { viewingKeyPair } = await umbra.generatePrivateKeys(recipient);
+
+        // Simulate sender encrypting the random number
+        const randomNumber = new RandomNumber();
+        const encrypted = viewingKeyPair.encrypt(randomNumber);
+
+        // Pull out the data that is published to chain and emitted as an event
+        const { ciphertext } = encrypted;
+        const { pubKeyXCoordinate } = KeyPair.compressPublicKey(encrypted.ephemeralPublicKey);
+
+        // Assume 02 prefix and decrypt
+        const uncompressedPubKey1 = KeyPair.getUncompressedFromX(pubKeyXCoordinate, 2);
+        const payload1 = { ephemeralPublicKey: uncompressedPubKey1, ciphertext };
+        const randomNumber1 = viewingKeyPair.decrypt(payload1);
+        expect(randomNumber1).to.equal(randomNumber.asHex);
+
+        // Assume 03 prefix and decrypt
+        const uncompressedPubKey2 = KeyPair.getUncompressedFromX(pubKeyXCoordinate, 3);
+        const payload2 = { ephemeralPublicKey: uncompressedPubKey2, ciphertext };
+        const randomNumber2 = viewingKeyPair.decrypt(payload2);
+        expect(randomNumber2).to.equal(randomNumber.asHex);
+        expect(uncompressedPubKey1).to.not.equal(uncompressedPubKey2); // confirm we took different paths to same result
+      }
+    });
+
+    it('properly derives public key parameters with both key-based constructor methods', () => {
+      const keyPair1 = new KeyPair(wallet.privateKey);
+      const keyPair2 = new KeyPair(wallet.publicKey);
+
+      expect(keyPair1.publicKeyHex).to.equal(keyPair2.publicKeyHex);
+      expect(JSON.stringify(keyPair1.publicKeyEC)).to.equal(JSON.stringify(keyPair2.publicKeyEC));
+    });
+
+    it('supports encryption and decryption of the random number', async () => {
+      // Do a bunch of tests with random wallets and numbers
+      for (let i = 0; i < numberOfRuns; i += 1) {
+        // Every 100th run, print status update and use the zero payload extension
+        let randomNumber: RandomNumber;
+        if ((i + 1) % 100 === 0) {
+          console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
+          randomNumber = generateRandomNumber(zeroPrefix);
+        } else {
+          randomNumber = generateRandomNumber();
+        }
+
+        // Generate random wallet and encrypt payload
+        const wallet = Wallet.createRandom();
+        const keyPairFromPublic = new KeyPair(wallet.publicKey);
+        const output = await keyPairFromPublic.encrypt(randomNumber); // eslint-disable-line no-await-in-loop
+
+        // Decrypt payload
+        const keyPairFromPrivate = new KeyPair(wallet.privateKey);
+        const plaintext = await keyPairFromPrivate.decrypt(output); // eslint-disable-line no-await-in-loop
+        expect(plaintext).to.equal(randomNumber.asHex);
+      }
+    });
+
+    it('lets sender generate stealth receiving address that recipient can access', () => {
+      for (let i = 0; i < numberOfRuns; i += 1) {
+        // Every 100th run, print status update and use the zero payload extension
+        let randomNumber: RandomNumber;
+        if ((i + 1) % 100 === 0) {
+          console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
+          randomNumber = generateRandomNumber(zeroPrefix);
+        } else {
+          randomNumber = generateRandomNumber();
+        }
+
+        // Sender computes receiving address from random number and recipient's public key
+        const recipientFromPublic = new KeyPair(wallet.publicKey);
+        const stealthFromPublic = recipientFromPublic.mulPublicKey(randomNumber);
+
+        // Recipient computes new private key from random number and derives receiving address
+        const recipientFromPrivate = new KeyPair(wallet.privateKey);
+        const stealthFromPrivate = recipientFromPrivate.mulPrivateKey(randomNumber);
+
+        // Confirm outputs match
+        expect(stealthFromPrivate.address).to.equal(stealthFromPublic.address);
+        expect(stealthFromPrivate.publicKeyHex).to.equal(stealthFromPublic.publicKeyHex);
+      }
+    });
+
+    it('lets multiplication be performed with RandomNumber class or hex string', () => {
+      for (let i = 0; i < numberOfRuns; i += 1) {
+        // Every 100th run, print status update and use the zero payload extension
+        let randomNumber: RandomNumber;
+        if ((i + 1) % 100 === 0) {
+          randomNumber = generateRandomNumber(zeroPrefix);
+          console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
+        } else {
+          randomNumber = generateRandomNumber();
+        }
+
+        // Generate random wallet
+        const randomWallet = Wallet.createRandom();
+        const randomFromPublic = new KeyPair(randomWallet.publicKey);
+        const randomFromPrivate = new KeyPair(randomWallet.privateKey);
+
+        // Compare public key multiplication
+        const stealthFromClassPublic = randomFromPublic.mulPublicKey(randomNumber);
+        const stealthFromStringPublic = randomFromPublic.mulPublicKey(randomNumber.asHex);
+        expect(stealthFromClassPublic.address).to.equal(stealthFromStringPublic.address);
+
+        // Compare private key multiplication
+        const stealthFromClassPrivate = randomFromPrivate.mulPrivateKey(randomNumber);
+        const stealthFromStringPrivate = randomFromPrivate.mulPrivateKey(randomNumber.asHex);
+        expect(stealthFromClassPrivate.address).to.equal(stealthFromStringPrivate.address);
+
+        const stealthFromClassPrivate2 = randomFromPrivate.mulPublicKey(randomNumber);
+        const stealthFromStringPrivate2 = randomFromPrivate.mulPublicKey(randomNumber.asHex);
+        expect(stealthFromClassPrivate2.address).to.equal(stealthFromStringPrivate2.address);
+      }
+    });
+
+    it('works for any randomly generated number and wallet', () => {
+      let numFailures = 0;
+      for (let i = 0; i < numberOfRuns; i += 1) {
+        // Every 100th run, print status update and use the zero payload extension
+        let randomNumber: RandomNumber;
+        if ((i + 1) % 100 === 0) {
+          console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
+          randomNumber = generateRandomNumber(zeroPrefix);
+        } else {
+          randomNumber = generateRandomNumber();
+        }
+
+        // Generate random wallet
+        const randomWallet = Wallet.createRandom();
+
+        // Sender computes receiving address from random number and recipient's public key
+        const recipientFromPublic = new KeyPair(randomWallet.publicKey);
+        const stealthFromPublic = recipientFromPublic.mulPublicKey(randomNumber);
+
+        // Recipient computes new private key from random number and derives receiving address
+        const recipientFromPrivate = new KeyPair(randomWallet.privateKey);
+        const stealthFromPrivate = recipientFromPrivate.mulPrivateKey(randomNumber);
+
+        // Confirm outputs match
+        if (
+          stealthFromPrivate.address !== stealthFromPublic.address ||
+          stealthFromPrivate.publicKeyHex !== stealthFromPublic.publicKeyHex
+        ) {
+          numFailures += 1;
+          console.log();
+          console.log(`FAILURE #${numFailures} ========================================`);
+          console.log('Inputs');
+          console.log('  Wallet Private Key:  ', wallet.privateKey);
+          console.log('  Wallet Public Key:   ', wallet.publicKey);
+          console.log('  Wallet Address:      ', wallet.address);
+          console.log('  Random Number:       ', randomNumber.asHex);
+          console.log('Outputs');
+          console.log('  Stealth from Public,  Address:     ', stealthFromPublic.address);
+          console.log('  Stealth from Private, Address:     ', stealthFromPrivate.address);
+          console.log('  Stealth from Public,  Public Key:  ', stealthFromPublic.publicKeyHex);
+          console.log('  Stealth from Private, Public Key:  ', stealthFromPrivate.publicKeyHex);
+        }
+      }
+      expect(numFailures).to.equal(0);
+    });
+  });
+
+  describe('Input validation', () => {
+    // ts-expect-error statements needed throughout this section to bypass TypeScript checks that would stop this file
+    // from being compiled/ran
+
+    it('throws when initializing with an invalid key', () => {
+      const errorMsg = 'Key must be a string in hex format with 0x prefix';
+      // @ts-expect-error
+      expect(() => new KeyPair(1)).to.throw(errorMsg);
+      expect(() => new KeyPair(privateKey.slice(2))).to.throw(errorMsg);
+      expect(() => new KeyPair(wallet.publicKey.slice(4))).to.throw(errorMsg);
+    });
+
+    it('throws when trying to encrypt with a bad input', async () => {
       const wallet = Wallet.createRandom();
       const keyPairFromPublic = new KeyPair(wallet.publicKey);
-      const output = await keyPairFromPublic.encrypt(randomNumber); // eslint-disable-line no-await-in-loop
+      const errorMsg = 'Must provide instance of RandomNumber';
+      // @ts-expect-error
+      expect(() => keyPairFromPublic.encrypt('1')).to.throw(errorMsg);
+      // @ts-expect-error
+      expect(() => keyPairFromPublic.encrypt(1)).to.throw(errorMsg);
+    });
 
-      // Decrypt payload
+    it('throws when trying to decrypt with a bad input', async () => {
+      const wallet = Wallet.createRandom();
       const keyPairFromPrivate = new KeyPair(wallet.privateKey);
-      const plaintext = await keyPairFromPrivate.decrypt(output); // eslint-disable-line no-await-in-loop
-      expect(plaintext).to.equal(randomNumber.asHex);
-    }
-  });
+      const errorMsg = 'Input must be of type EncryptedPayload to decrypt';
+      // @ts-expect-error
+      expect(() => keyPairFromPrivate.decrypt({ ephemeralPublicKey: '1' })).to.throw(errorMsg);
+      // @ts-expect-error
+      expect(() => keyPairFromPrivate.decrypt({ ciphertext: '1' })).to.throw(errorMsg);
+      // @ts-expect-error
+      expect(() => keyPairFromPrivate.decrypt('1')).to.throw(errorMsg);
+      // @ts-expect-error
+      expect(() => keyPairFromPrivate.decrypt(1)).to.throw(errorMsg);
+    });
 
-  it('lets sender generate stealth receiving address that recipient can access', () => {
-    for (let i = 0; i < numberOfRuns; i += 1) {
-      // Every 100th run, print status update and use the zero payload extension
-      let randomNumber: RandomNumber;
-      if ((i + 1) % 100 === 0) {
-        console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
-        randomNumber = generateRandomNumber(zeroPrefix);
-      } else {
-        randomNumber = generateRandomNumber();
-      }
+    it('throws when mulPublicKey is provided a bad input', async () => {
+      const wallet = Wallet.createRandom();
+      const keyPairFromPublic = new KeyPair(wallet.publicKey);
+      // @ts-expect-error
+      expect(() => keyPairFromPublic.mulPublicKey(1)).to.throw('Input must be instance of RandomNumber or string');
+      expect(() => keyPairFromPublic.mulPublicKey('1234')).to.throw('Strings must be in hex form with 0x prefix');
+    });
 
-      // Sender computes receiving address from random number and recipient's public key
-      const recipientFromPublic = new KeyPair(wallet.publicKey);
-      const stealthFromPublic = recipientFromPublic.mulPublicKey(randomNumber);
+    it('throws when mulPrivateKey is provided a bad input', async () => {
+      const wallet = Wallet.createRandom();
+      const keyPairFromPrivate = new KeyPair(wallet.privateKey);
+      const keyPairFromPublic = new KeyPair(wallet.publicKey);
+      // @ts-expect-error
+      expect(() => keyPairFromPrivate.mulPrivateKey(1)).to.throw('Input must be instance of RandomNumber or string');
+      expect(() => keyPairFromPrivate.mulPrivateKey('1234')).to.throw('Strings must be in hex form with 0x prefix');
+      expect(() => keyPairFromPublic.mulPrivateKey('0x1')).to.throw('KeyPair has no associated private key');
+    });
 
-      // Recipient computes new private key from random number and derives receiving address
-      const recipientFromPrivate = new KeyPair(wallet.privateKey);
-      const stealthFromPrivate = recipientFromPrivate.mulPrivateKey(randomNumber);
+    it('throws when instanceFromTransaction is provided an invalid transaction hash', async () => {
+      const errorMsg = 'Invalid transaction hash provided';
+      // @ts-expect-error
+      expectRejection(KeyPair.instanceFromTransaction(1, ethersProvider), errorMsg);
+      expectRejection(KeyPair.instanceFromTransaction('0x1', ethersProvider), errorMsg);
+    });
 
-      // Confirm outputs match
-      expect(stealthFromPrivate.address).to.equal(stealthFromPublic.address);
-      expect(stealthFromPrivate.publicKeyHex).to.equal(stealthFromPublic.publicKeyHex);
-    }
-  });
+    it('throws when compressPublicKey is provided bad inputs', async () => {
+      const errorMsg = 'Must provide uncompressed public key as hex string';
+      // @ts-expect-error
+      expect(() => KeyPair.compressPublicKey(1)).to.throw(errorMsg);
+      expect(() => KeyPair.compressPublicKey('1')).to.throw(errorMsg);
+      expect(() => KeyPair.compressPublicKey('0x1')).to.throw(errorMsg);
+    });
 
-  it('lets multiplication be performed with RandomNumber class or hex string', () => {
-    for (let i = 0; i < numberOfRuns; i += 1) {
-      // Every 100th run, print status update and use the zero payload extension
-      let randomNumber: RandomNumber;
-      if ((i + 1) % 100 === 0) {
-        randomNumber = generateRandomNumber(zeroPrefix);
-        console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
-      } else {
-        randomNumber = generateRandomNumber();
-      }
-
-      // Generate random wallet
-      const randomWallet = Wallet.createRandom();
-      const randomFromPublic = new KeyPair(randomWallet.publicKey);
-      const randomFromPrivate = new KeyPair(randomWallet.privateKey);
-
-      // Compare public key multiplication
-      const stealthFromClassPublic = randomFromPublic.mulPublicKey(randomNumber);
-      const stealthFromStringPublic = randomFromPublic.mulPublicKey(randomNumber.asHex);
-      expect(stealthFromClassPublic.address).to.equal(stealthFromStringPublic.address);
-
-      // Compare private key multiplication
-      const stealthFromClassPrivate = randomFromPrivate.mulPrivateKey(randomNumber);
-      const stealthFromStringPrivate = randomFromPrivate.mulPrivateKey(randomNumber.asHex);
-      expect(stealthFromClassPrivate.address).to.equal(stealthFromStringPrivate.address);
-
-      const stealthFromClassPrivate2 = randomFromPrivate.mulPublicKey(randomNumber);
-      const stealthFromStringPrivate2 = randomFromPrivate.mulPublicKey(randomNumber.asHex);
-      expect(stealthFromClassPrivate2.address).to.equal(stealthFromStringPrivate2.address);
-    }
-  });
-
-  it('works for any randomly generated number and wallet', () => {
-    let numFailures = 0;
-    for (let i = 0; i < numberOfRuns; i += 1) {
-      // Every 100th run, print status update and use the zero payload extension
-      let randomNumber: RandomNumber;
-      if ((i + 1) % 100 === 0) {
-        console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
-        randomNumber = generateRandomNumber(zeroPrefix);
-      } else {
-        randomNumber = generateRandomNumber();
-      }
-
-      // Generate random wallet
-      const randomWallet = Wallet.createRandom();
-
-      // Sender computes receiving address from random number and recipient's public key
-      const recipientFromPublic = new KeyPair(randomWallet.publicKey);
-      const stealthFromPublic = recipientFromPublic.mulPublicKey(randomNumber);
-
-      // Recipient computes new private key from random number and derives receiving address
-      const recipientFromPrivate = new KeyPair(randomWallet.privateKey);
-      const stealthFromPrivate = recipientFromPrivate.mulPrivateKey(randomNumber);
-
-      // Confirm outputs match
-      if (
-        stealthFromPrivate.address !== stealthFromPublic.address ||
-        stealthFromPrivate.publicKeyHex !== stealthFromPublic.publicKeyHex
-      ) {
-        numFailures += 1;
-        console.log();
-        console.log(`FAILURE #${numFailures} ========================================`);
-        console.log('Inputs');
-        console.log('  Wallet Private Key:  ', wallet.privateKey);
-        console.log('  Wallet Public Key:   ', wallet.publicKey);
-        console.log('  Wallet Address:      ', wallet.address);
-        console.log('  Random Number:       ', randomNumber.asHex);
-        console.log('Outputs');
-        console.log('  Stealth from Public,  Address:     ', stealthFromPublic.address);
-        console.log('  Stealth from Private, Address:     ', stealthFromPrivate.address);
-        console.log('  Stealth from Public,  Public Key:  ', stealthFromPublic.publicKeyHex);
-        console.log('  Stealth from Private, Public Key:  ', stealthFromPrivate.publicKeyHex);
-      }
-    }
-    expect(numFailures).to.equal(0);
+    it('throws when getUncompressedFromX is provided bad inputs', async () => {
+      // @ts-expect-error
+      expect(() => KeyPair.getUncompressedFromX(1)).to.throw('Compressed public key must be a BigNumber or string');
+    });
   });
 });

--- a/umbra-js/test/ens.test.ts
+++ b/umbra-js/test/ens.test.ts
@@ -16,6 +16,19 @@ const nameViewingPublicKey =
   '0x041190b7e2b61b8872c9ea5fff14770e7d3e78900282371b09ee9f2b8c4016b9967b5e9ee9e1e0bef30052e806321f0685a3ad69e2233be6813b81a5d293feea76';
 
 describe('ENS functions', () => {
+  it('properly identifies ENS domains', async () => {
+    ens.supportedEnsDomains.forEach((suffix) => {
+      // example suffixes: .eth, .xyz, etc.
+      expect(ens.isEnsDomain(`test${suffix}`)).to.be.true;
+    });
+  });
+
+  it('namehash throws when given a bad ENS suffix', async () => {
+    const badName = 'myname.com';
+    const errorMsg = `Name does not end with supported suffix: ${ens.supportedEnsDomains.join(', ')}`;
+    expect(() => ens.namehash(badName)).to.throw(errorMsg);
+  });
+
   it('computes the namehash of an ENS domain', () => {
     const hash = ens.namehash('msolomon.eth');
     expect(hash).to.equal('0xbe0b801f52a20451e2845cf346b7c8de65f4beca0ebba17c14ce601de7bbc7fb');


### PR DESCRIPTION
Changes:
- To assist users who integrate with JavaScript instead of TypeScript, we add stricter input validation to methods in `umbra-js`.
- Bump minimum elliptic version to 6.5.4 since older versions had vulnerabilities
- Remove unused class getters to clean up `KeyPair.ts`
- We also expand the list of supported ENS domains

One current issue is that on commit I get the below error. I tried to make a change to the `tsconfig.json` file, but this didn't seem to work, cc @wildmolasses 

![image](https://user-images.githubusercontent.com/17163988/110130751-372d5080-7d7e-11eb-9d67-bbbfb977e703.png)
