### PR TITLE
Implement And Test Post Withdraw Hooks

### DIFF
--- a/contracts/contracts/IUmbraHookReceiver.sol
+++ b/contracts/contracts/IUmbraHookReceiver.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.6.12;
 
 /// @dev Interface that post-withdraw hooks must implement to interop with Umbra
-interface UmbraHookable {
+interface IUmbraHookReceiver {
   /**
    * @notice Method called after a user completes an Umbra token withdrawal
    * @param _amount The amount of the token withdrawn _after_ subtracting the sponsor fee

--- a/contracts/contracts/MockHook.sol
+++ b/contracts/contracts/MockHook.sol
@@ -2,10 +2,10 @@
 
 pragma solidity ^0.6.12;
 
-import "./UmbraHookable.sol";
+import "./IUmbraHookReceiver.sol";
 
 /// @dev Mock implementation of UmbraHookable used for testing
-contract MockHook is UmbraHookable {
+contract MockHook is IUmbraHookReceiver {
 
     struct CallHookData {
         uint256 amount;

--- a/contracts/contracts/MockHook.sol
+++ b/contracts/contracts/MockHook.sol
@@ -19,7 +19,7 @@ contract MockHook is UmbraHookable {
 
     CallHookData public lastCallData;
 
-    function callHook (
+    function tokensWithdrawn (
         uint256 _amount,
         address _stealthAddr,
         address _acceptor,

--- a/contracts/contracts/MockHook.sol
+++ b/contracts/contracts/MockHook.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.12;
+
+import "./UmbraHookable.sol";
+
+/// @dev Mock implementation of UmbraHookable used for testing
+contract MockHook is UmbraHookable {
+
+    struct CallHookData {
+        uint256 amount;
+        address stealthAddr;
+        address acceptor;
+        address tokenAddr;
+        address sponsor;
+        uint256 sponsorFee;
+        bytes data;
+    }
+
+    CallHookData public lastCallData;
+
+    function callHook (
+        uint256 _amount,
+        address _stealthAddr,
+        address _acceptor,
+        address _tokenAddr,
+        address _sponsor,
+        uint256 _sponsorFee,
+        bytes memory _data
+    ) external override {
+        lastCallData = CallHookData({
+            amount: _amount,
+            stealthAddr: _stealthAddr,
+            acceptor: _acceptor,
+            tokenAddr: _tokenAddr,
+            sponsor: _sponsor,
+            sponsorFee: _sponsorFee,
+            data: _data
+        });
+    }
+}

--- a/contracts/contracts/Umbra.sol
+++ b/contracts/contracts/Umbra.sol
@@ -242,7 +242,16 @@ contract Umbra is Ownable {
     _withdrawTokenInternal(_stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, _hook, _data);
   }
 
-  /// @dev low level withdrawal function that should only be called after safety checks
+  /**
+   * @notice Low level withdrawal function that should only be called after safety checks
+   * @param _stealthAddr The stealth address whose token balance will be withdrawn
+   * @param _acceptor Address where withdrawn funds should be sent
+   * @param _tokenAddr Address of the ERC20 token being withdrawn
+   * @param _sponsor Address which is compensated for submitting the withdrawal tx
+   * @param _sponsorFee Amount of the token to pay to the sponsor
+   * @param _hook Contract that will be called after the token withdrawal has completed
+   * @param _data Arbitrary data that will be passed to the post-withdraw hook contract
+   */
   function _withdrawTokenInternal(
     address _stealthAddr,
     address _acceptor,
@@ -254,7 +263,7 @@ contract Umbra is Ownable {
   ) internal {
     uint256 _amount = tokenPayments[_stealthAddr][_tokenAddr];
 
-    // also protects from underflow and re-entrance
+    // also protects from underflow
     require(_amount > _sponsorFee, "Umbra: No balance to withdraw or fee exceeds balance");
 
     uint256 _withdrawalAmount = _amount - _sponsorFee;
@@ -272,7 +281,19 @@ contract Umbra is Ownable {
     }
   }
 
-  /// @dev recovers address from signature of the parameters and throws if not _stealthAddr
+  /**
+   * @notice Internal method which recovers address from signature of the parameters and throws if not _stealthAddr
+   * @param _stealthAddr The stealth address whose token balance will be withdrawn
+   * @param _acceptor Address where withdrawn funds should be sent
+   * @param _tokenAddr Address of the ERC20 token being withdrawn
+   * @param _sponsor Address which is compensated for submitting the withdrawal tx
+   * @param _sponsorFee Amount of the token to pay to the sponsor
+   * @param _hook Contract that will be called after the token withdrawal has completed
+   * @param _data Arbitrary data that will be passed to the post-withdraw hook contract
+   * @param _v ECDSA signature component: Parity of the `y` coordinate of point `R`
+   * @param _r ECDSA signature component: x-coordinate of `R`
+   * @param _s ECDSA signature component: `s` value of the signature
+   */
   function _validateWithdrawSignature(
     address _stealthAddr,
     address _acceptor,

--- a/contracts/contracts/Umbra.sol
+++ b/contracts/contracts/Umbra.sol
@@ -171,6 +171,14 @@ contract Umbra is Ownable {
     _withdrawTokenInternal(msg.sender, _acceptor, _tokenAddr, address(0), 0, UmbraHookable(0), "");
   }
 
+  /**
+   * @notice Withdraw an ERC20 token payment sent to a stealth address
+   * @dev This method must be directly called by the stealth address
+   * @param _acceptor Address where withdrawn funds should be sent
+   * @param _tokenAddr Address of the ERC20 token being withdrawn
+   * @param _hook Contract that will be called after the token withdrawal has completed
+   * @param _data Arbitrary data that will be passed to the post-withdraw hook contract
+   */
   function withdrawTokenAndCall(
     address _acceptor,
     address _tokenAddr,
@@ -186,7 +194,7 @@ contract Umbra is Ownable {
    * @param _acceptor Address where withdrawn funds should be sent
    * @param _tokenAddr Address of the ERC20 token being withdrawn
    * @param _sponsor Address which is compensated for submitting the withdrawal tx
-   * @param _sponsorFee Amount of the token to pay to the transfer
+   * @param _sponsorFee Amount of the token to pay to the sponsor
    * @param _v ECDSA signature component: Parity of the `y` coordinate of point `R`
    * @param _r ECDSA signature component: x-coordinate of `R`
    * @param _s ECDSA signature component: `s` value of the signature
@@ -205,6 +213,19 @@ contract Umbra is Ownable {
     _withdrawTokenInternal(_stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, UmbraHookable(0), "");
   }
 
+  /**
+   * @notice Withdraw an ERC20 token payment on behalf of a stealth address via signed authorization
+   * @param _stealthAddr The stealth address whose token balance will be withdrawn
+   * @param _acceptor Address where withdrawn funds should be sent
+   * @param _tokenAddr Address of the ERC20 token being withdrawn
+   * @param _sponsor Address which is compensated for submitting the withdrawal tx
+   * @param _sponsorFee Amount of the token to pay to the sponsor
+   * @param _hook Contract that will be called after the token withdrawal has completed
+   * @param _data Arbitrary data that will be passed to the post-withdraw hook contract
+   * @param _v ECDSA signature component: Parity of the `y` coordinate of point `R`
+   * @param _r ECDSA signature component: x-coordinate of `R`
+   * @param _s ECDSA signature component: `s` value of the signature
+   */
   function withdrawTokenAndCallOnBehalf(
     address _stealthAddr,
     address _acceptor,
@@ -251,7 +272,7 @@ contract Umbra is Ownable {
     }
   }
 
-  /// @dev recovers address from signature of the parameters past and throws if not _stealthAddr
+  /// @dev recovers address from signature of the parameters and throws if not _stealthAddr
   function _validateWithdrawSignature(
     address _stealthAddr,
     address _acceptor,

--- a/contracts/contracts/Umbra.sol
+++ b/contracts/contracts/Umbra.sol
@@ -201,25 +201,7 @@ contract Umbra is Ownable {
     bytes32 _r,
     bytes32 _s
   ) external {
-    bytes32 _digest =
-      keccak256(
-        abi.encodePacked("\x19Ethereum Signed Message:\n32",
-          keccak256(
-            abi.encode(
-              chainId,
-              version,
-              _acceptor,
-              _tokenAddr,
-              _sponsor,
-              _sponsorFee
-            )
-          )
-        )
-      );
-
-    address _recoveredAddress = ecrecover(_digest, _v, _r, _s);
-    require(_recoveredAddress != address(0) && _recoveredAddress == _stealthAddr, "Umbra: Invalid Signature");
-
+    _validateWithdrawSignature(_stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, _v, _r, _s);
     _withdrawTokenInternal(_stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, UmbraHookable(0), "");
   }
 
@@ -251,5 +233,36 @@ contract Umbra is Ownable {
     if (address(_hook) != address(0)) {
       _hook.callHook(_withdrawalAmount, _stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, _data);
     }
+  }
+
+  /// @dev recovers address from signature of the parameters past and throws if not _stealthAddr
+  function _validateWithdrawSignature(
+    address _stealthAddr,
+    address _acceptor,
+    address _tokenAddr,
+    address _sponsor,
+    uint256 _sponsorFee,
+    uint8 _v,
+    bytes32 _r,
+    bytes32 _s
+  ) internal {
+    bytes32 _digest =
+      keccak256(
+        abi.encodePacked("\x19Ethereum Signed Message:\n32",
+          keccak256(
+            abi.encode(
+              chainId,
+              version,
+              _acceptor,
+              _tokenAddr,
+              _sponsor,
+              _sponsorFee
+            )
+          )
+        )
+      );
+
+    address _recoveredAddress = ecrecover(_digest, _v, _r, _s);
+    require(_recoveredAddress != address(0) && _recoveredAddress == _stealthAddr, "Umbra: Invalid Signature");
   }
 }

--- a/contracts/contracts/Umbra.sol
+++ b/contracts/contracts/Umbra.sol
@@ -205,6 +205,22 @@ contract Umbra is Ownable {
     _withdrawTokenInternal(_stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, UmbraHookable(0), "");
   }
 
+  function withdrawTokenAndCallOnBehalf(
+    address _stealthAddr,
+    address _acceptor,
+    address _tokenAddr,
+    address _sponsor,
+    uint256 _sponsorFee,
+    UmbraHookable _hook,
+    bytes memory _data,
+    uint8 _v,
+    bytes32 _r,
+    bytes32 _s
+  ) external {
+    _validateWithdrawSignature(_stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, _hook, _data, _v, _r, _s);
+    _withdrawTokenInternal(_stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, _hook, _data);
+  }
+
   /// @dev low level withdrawal function that should only be called after safety checks
   function _withdrawTokenInternal(
     address _stealthAddr,
@@ -247,7 +263,7 @@ contract Umbra is Ownable {
     uint8 _v,
     bytes32 _r,
     bytes32 _s
-  ) internal {
+  ) internal view {
     bytes32 _digest =
       keccak256(
         abi.encodePacked("\x19Ethereum Signed Message:\n32",

--- a/contracts/contracts/Umbra.sol
+++ b/contracts/contracts/Umbra.sol
@@ -268,7 +268,7 @@ contract Umbra is Ownable {
     }
 
     if (address(_hook) != address(0)) {
-      _hook.callHook(_withdrawalAmount, _stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, _data);
+      _hook.tokensWithdrawn(_withdrawalAmount, _stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, _data);
     }
   }
 

--- a/contracts/contracts/Umbra.sol
+++ b/contracts/contracts/Umbra.sol
@@ -201,7 +201,7 @@ contract Umbra is Ownable {
     bytes32 _r,
     bytes32 _s
   ) external {
-    _validateWithdrawSignature(_stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, _v, _r, _s);
+    _validateWithdrawSignature(_stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, UmbraHookable(0), "", _v, _r, _s);
     _withdrawTokenInternal(_stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, UmbraHookable(0), "");
   }
 
@@ -242,6 +242,8 @@ contract Umbra is Ownable {
     address _tokenAddr,
     address _sponsor,
     uint256 _sponsorFee,
+    UmbraHookable _hook,
+    bytes memory _data,
     uint8 _v,
     bytes32 _r,
     bytes32 _s
@@ -256,7 +258,9 @@ contract Umbra is Ownable {
               _acceptor,
               _tokenAddr,
               _sponsor,
-              _sponsorFee
+              _sponsorFee,
+              address(_hook),
+              _data
             )
           )
         )

--- a/contracts/contracts/Umbra.sol
+++ b/contracts/contracts/Umbra.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.6.12;
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "./UmbraHookable.sol";
+import "./IUmbraHookReceiver.sol";
 
 contract Umbra is Ownable {
   using SafeMath for uint256;
@@ -168,7 +168,7 @@ contract Umbra is Ownable {
    * @param _tokenAddr Address of the ERC20 token being withdrawn
    */
   function withdrawToken(address _acceptor, address _tokenAddr) external {
-    _withdrawTokenInternal(msg.sender, _acceptor, _tokenAddr, address(0), 0, UmbraHookable(0), "");
+    _withdrawTokenInternal(msg.sender, _acceptor, _tokenAddr, address(0), 0, IUmbraHookReceiver(0), "");
   }
 
   /**
@@ -182,7 +182,7 @@ contract Umbra is Ownable {
   function withdrawTokenAndCall(
     address _acceptor,
     address _tokenAddr,
-    UmbraHookable _hook,
+    IUmbraHookReceiver _hook,
     bytes memory _data
   ) external {
     _withdrawTokenInternal(msg.sender, _acceptor, _tokenAddr, address(0), 0, _hook, _data);
@@ -209,8 +209,8 @@ contract Umbra is Ownable {
     bytes32 _r,
     bytes32 _s
   ) external {
-    _validateWithdrawSignature(_stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, UmbraHookable(0), "", _v, _r, _s);
-    _withdrawTokenInternal(_stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, UmbraHookable(0), "");
+    _validateWithdrawSignature(_stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, IUmbraHookReceiver(0), "", _v, _r, _s);
+    _withdrawTokenInternal(_stealthAddr, _acceptor, _tokenAddr, _sponsor, _sponsorFee, IUmbraHookReceiver(0), "");
   }
 
   /**
@@ -232,7 +232,7 @@ contract Umbra is Ownable {
     address _tokenAddr,
     address _sponsor,
     uint256 _sponsorFee,
-    UmbraHookable _hook,
+    IUmbraHookReceiver _hook,
     bytes memory _data,
     uint8 _v,
     bytes32 _r,
@@ -258,7 +258,7 @@ contract Umbra is Ownable {
     address _tokenAddr,
     address _sponsor,
     uint256 _sponsorFee,
-    UmbraHookable _hook,
+    IUmbraHookReceiver _hook,
     bytes memory _data
   ) internal {
     uint256 _amount = tokenPayments[_stealthAddr][_tokenAddr];
@@ -300,7 +300,7 @@ contract Umbra is Ownable {
     address _tokenAddr,
     address _sponsor,
     uint256 _sponsorFee,
-    UmbraHookable _hook,
+    IUmbraHookReceiver _hook,
     bytes memory _data,
     uint8 _v,
     bytes32 _r,

--- a/contracts/contracts/UmbraHookable.sol
+++ b/contracts/contracts/UmbraHookable.sol
@@ -14,7 +14,7 @@ interface UmbraHookable {
    * @param _sponsorFee Amount of the token that was paid to the sponsor
    * @param _data Arbitrary data passed to this hook by the withdrawer
    */
-  function callHook(
+  function tokensWithdrawn(
     uint256 _amount,
     address _stealthAddr,
     address _acceptor,

--- a/contracts/contracts/UmbraHookable.sol
+++ b/contracts/contracts/UmbraHookable.sol
@@ -2,15 +2,25 @@
 
 pragma solidity ^0.6.12;
 
+/// @dev Interface that post-withdraw hooks must implement to interop with Umbra
 interface UmbraHookable {
-
-    function callHook (
-        uint256 _amount,
-        address _stealthAddr,
-        address _acceptor,
-        address _tokenAddr,
-        address _sponsor,
-        uint256 _sponsorFee,
-        bytes memory _data
-    ) external;
+  /**
+   * @notice Method called after a user completes an Umbra token withdrawal
+   * @param _amount The amount of the token withdrawn _after_ subtracting the sponsor fee
+   * @param _stealthAddr The stealth address whose token balance was withdrawn
+   * @param _acceptor Address where withdrawn funds were sent; can be this contract
+   * @param _tokenAddr Address of the ERC20 token that was withdrawn
+   * @param _sponsor Address which was compensated for submitting the withdrawal tx
+   * @param _sponsorFee Amount of the token that was paid to the sponsor
+   * @param _data Arbitrary data passed to this hook by the withdrawer
+   */
+  function callHook(
+    uint256 _amount,
+    address _stealthAddr,
+    address _acceptor,
+    address _tokenAddr,
+    address _sponsor,
+    uint256 _sponsorFee,
+    bytes memory _data
+  ) external;
 }

--- a/contracts/contracts/UmbraHookable.sol
+++ b/contracts/contracts/UmbraHookable.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.12;
+
+interface UmbraHookable {
+
+    function callHook (
+        uint256 _amount,
+        address _stealthAddr,
+        address _acceptor,
+        address _tokenAddr,
+        address _sponsor,
+        uint256 _sponsorFee,
+        bytes memory _data
+    ) external;
+}

--- a/contracts/test/umbra-hook-test.js
+++ b/contracts/test/umbra-hook-test.js
@@ -93,7 +93,7 @@ describe('Umbra Hooks', () => {
     it('should call the hook contract when the stealth receiver withdraws directly with empty data', async () => {
       await mintAndSendToken(sender, receiver, '100');
 
-      await ctx.umbra.withdrawTokenAndCall(acceptor, ctx.token.address, ctx.hook.address, [], {
+      await ctx.umbra.withdrawTokenAndCall(acceptor, ctx.token.address, ctx.hook.address, '0x', {
         from: receiver,
       });
 
@@ -215,7 +215,7 @@ describe('Umbra Hooks', () => {
         relayer,
         relayerTokenFee,
         ctx.hook.address,
-        []
+        '0x'
       );
 
       const receipt = await ctx.umbra.withdrawTokenAndCallOnBehalf(
@@ -225,7 +225,7 @@ describe('Umbra Hooks', () => {
         relayer,
         relayerTokenFee,
         ctx.hook.address,
-        [],
+        '0x',
         v,
         r,
         s,

--- a/contracts/test/umbra-hook-test.js
+++ b/contracts/test/umbra-hook-test.js
@@ -12,9 +12,16 @@ const AddressZero = ethers.constants.AddressZero;
 
 describe('Umbra Hooks', () => {
   const ctx = {};
-  let owner, sender, receiver, acceptor;
+  let owner, sender, receiver, acceptor, relayer;
 
+  // amount that will be configured as the eth toll
   const toll = toWei('0.01', 'ether');
+
+  // token fee the relayer will charge for meta-tx withdrawal
+  const relayerTokenFee = toWei('2', 'ether');
+
+  // The ethers wallet that will be used when testing meta tx withdrawals
+  const metaWallet = ethers.Wallet.createRandom();
 
   // helper function to mint test tokens
   const mintToken = async (toAddr, amount) => {
@@ -40,12 +47,16 @@ describe('Umbra Hooks', () => {
     await sendToken(fromAddr, stealthAddr, amount);
   };
 
-  beforeEach(async () => {
-    [owner, sender, receiver, acceptor] = await web3.eth.getAccounts();
+  before(async () => {
+    [owner, sender, receiver, acceptor, relayer] = await web3.eth.getAccounts();
+    ctx.chainId = await web3.eth.getChainId();
+  });
 
+  beforeEach(async () => {
     ctx.umbra = await Umbra.new(toll, owner, owner, { from: owner });
     ctx.token = await TestToken.new('TestToken', 'TT');
     ctx.hook = await MockHook.new();
+    ctx.version = await ctx.umbra.version();
   });
 
   it('should see the deployed Umbra contract', async () => {
@@ -71,7 +82,7 @@ describe('Umbra Hooks', () => {
     expect(callData.acceptor).to.equal(acceptor);
     expect(callData.tokenAddr).to.equal(ctx.token.address);
     expect(callData.sponsor).to.equal(AddressZero);
-    expect(callData.sponsorFee.toString()).to.equal('0');
+    expect(fromWei(callData.sponsorFee)).to.equal('0');
     expect(callData.data).to.equal('0xbeefc0ffee');
 
     const balance = await ctx.token.balanceOf(acceptor);
@@ -92,32 +103,9 @@ describe('Umbra Hooks', () => {
     expect(callData.acceptor).to.equal(acceptor);
     expect(callData.tokenAddr).to.equal(ctx.token.address);
     expect(callData.sponsor).to.equal(AddressZero);
-    expect(callData.sponsorFee.toString()).to.equal('0');
+    expect(fromWei(callData.sponsorFee)).to.equal('0');
     expect(callData.data).to.equal(null);
 
-    const balance = await ctx.token.balanceOf(acceptor);
-    expect(fromWei(balance)).to.equal('100');
-  });
-
-  it('should not call the hook if the hook address is 0', async () => {
-    await mintAndSendToken(sender, receiver, '100');
-
-    await ctx.umbra.withdrawTokenAndCall(acceptor, ctx.token.address, AddressZero, '0xbeefc0ffee', {
-      from: receiver,
-    });
-
-    const callData = await ctx.hook.lastCallData();
-
-    // call data in the mock trigger is just still zeroes
-    expect(fromWei(callData.amount)).to.equal('0');
-    expect(callData.stealthAddr).to.equal(AddressZero);
-    expect(callData.acceptor).to.equal(AddressZero);
-    expect(callData.tokenAddr).to.equal(AddressZero);
-    expect(callData.sponsor).to.equal(AddressZero);
-    expect(callData.sponsorFee.toString()).to.equal('0');
-    expect(callData.data).to.equal(null);
-
-    // the withdrawal  transfer should still work
     const balance = await ctx.token.balanceOf(acceptor);
     expect(fromWei(balance)).to.equal('100');
   });
@@ -136,10 +124,284 @@ describe('Umbra Hooks', () => {
     expect(callData.acceptor).to.equal(ctx.hook.address);
     expect(callData.tokenAddr).to.equal(ctx.token.address);
     expect(callData.sponsor).to.equal(AddressZero);
-    expect(callData.sponsorFee.toString()).to.equal('0');
+    expect(fromWei(callData.sponsorFee)).to.equal('0');
     expect(callData.data).to.equal('0xbeefc0ffee');
 
     const balance = await ctx.token.balanceOf(ctx.hook.address);
     expect(fromWei(balance)).to.equal('100');
+  });
+
+  it('should not call the hook when the stealth receiver withdraws directly if the hook address is 0', async () => {
+    await mintAndSendToken(sender, receiver, '100');
+
+    await ctx.umbra.withdrawTokenAndCall(acceptor, ctx.token.address, AddressZero, '0xbeefc0ffee', {
+      from: receiver,
+    });
+
+    const callData = await ctx.hook.lastCallData();
+
+    // call data in the mock trigger should still be zeroes
+    expect(fromWei(callData.amount)).to.equal('0');
+    expect(callData.stealthAddr).to.equal(AddressZero);
+    expect(callData.acceptor).to.equal(AddressZero);
+    expect(callData.tokenAddr).to.equal(AddressZero);
+    expect(callData.sponsor).to.equal(AddressZero);
+    expect(fromWei(callData.sponsorFee)).to.equal('0');
+    expect(callData.data).to.equal(null);
+
+    // the withdrawal  transfer should still work
+    const balance = await ctx.token.balanceOf(acceptor);
+    expect(fromWei(balance)).to.equal('100');
+  });
+
+  it('should call the hook contract when the stealth receiver withdraws via meta tx', async () => {
+    await mintAndSendToken(sender, metaWallet.address, '100');
+
+    const { v, r, s } = await signMetaWithdrawal(
+      metaWallet,
+      ctx.chainId,
+      ctx.version,
+      acceptor,
+      ctx.token.address,
+      relayer,
+      relayerTokenFee,
+      ctx.hook.address,
+      '0xbeefc0ffee'
+    );
+
+    const receipt = await ctx.umbra.withdrawTokenAndCallOnBehalf(
+      metaWallet.address,
+      acceptor,
+      ctx.token.address,
+      relayer,
+      relayerTokenFee,
+      ctx.hook.address,
+      '0xbeefc0ffee',
+      v,
+      r,
+      s,
+      { from: relayer }
+    );
+
+    const callData = await ctx.hook.lastCallData();
+
+    expect(fromWei(callData.amount)).to.equal('98');
+    expect(callData.stealthAddr).to.equal(metaWallet.address);
+    expect(callData.acceptor).to.equal(acceptor);
+    expect(callData.tokenAddr).to.equal(ctx.token.address);
+    expect(callData.sponsor).to.equal(relayer);
+    expect(fromWei(callData.sponsorFee)).to.equal('2');
+    expect(callData.data).to.equal('0xbeefc0ffee');
+
+    const balance = await ctx.token.balanceOf(acceptor);
+    expect(fromWei(balance)).to.equal('98');
+
+    const sponsorBalance = await ctx.token.balanceOf(relayer);
+    expect(fromWei(sponsorBalance)).to.equal('2');
+  });
+
+  it('should call the hook contract when the stealth receiver withdraws via meta tx with empty data', async () => {
+    await mintAndSendToken(sender, metaWallet.address, '100');
+
+    const { v, r, s } = await signMetaWithdrawal(
+      metaWallet,
+      ctx.chainId,
+      ctx.version,
+      acceptor,
+      ctx.token.address,
+      relayer,
+      relayerTokenFee,
+      ctx.hook.address,
+      []
+    );
+
+    const receipt = await ctx.umbra.withdrawTokenAndCallOnBehalf(
+      metaWallet.address,
+      acceptor,
+      ctx.token.address,
+      relayer,
+      relayerTokenFee,
+      ctx.hook.address,
+      [],
+      v,
+      r,
+      s,
+      { from: relayer }
+    );
+
+    const callData = await ctx.hook.lastCallData();
+
+    expect(fromWei(callData.amount)).to.equal('98');
+    expect(callData.stealthAddr).to.equal(metaWallet.address);
+    expect(callData.acceptor).to.equal(acceptor);
+    expect(callData.tokenAddr).to.equal(ctx.token.address);
+    expect(callData.sponsor).to.equal(relayer);
+    expect(fromWei(callData.sponsorFee)).to.equal('2');
+    expect(callData.data).to.equal(null);
+
+    const balance = await ctx.token.balanceOf(acceptor);
+    expect(fromWei(balance)).to.equal('98');
+
+    const sponsorBalance = await ctx.token.balanceOf(relayer);
+    expect(fromWei(sponsorBalance)).to.equal('2');
+  });
+
+  it('should not call the hook if the hook contract is 0 when the stealth receiver withdraws via meta tx', async () => {
+    await mintAndSendToken(sender, metaWallet.address, '100');
+
+    const { v, r, s } = await signMetaWithdrawal(
+      metaWallet,
+      ctx.chainId,
+      ctx.version,
+      acceptor,
+      ctx.token.address,
+      relayer,
+      relayerTokenFee,
+      AddressZero,
+      '0xbeefc0ffee'
+    );
+
+    const receipt = await ctx.umbra.withdrawTokenAndCallOnBehalf(
+      metaWallet.address,
+      acceptor,
+      ctx.token.address,
+      relayer,
+      relayerTokenFee,
+      AddressZero,
+      '0xbeefc0ffee',
+      v,
+      r,
+      s,
+      { from: relayer }
+    );
+
+    const callData = await ctx.hook.lastCallData();
+
+    // call data in the mock trigger should still be zeroes
+    expect(fromWei(callData.amount)).to.equal('0');
+    expect(callData.stealthAddr).to.equal(AddressZero);
+    expect(callData.acceptor).to.equal(AddressZero);
+    expect(callData.tokenAddr).to.equal(AddressZero);
+    expect(callData.sponsor).to.equal(AddressZero);
+    expect(fromWei(callData.sponsorFee)).to.equal('0');
+    expect(callData.data).to.equal(null);
+
+    const balance = await ctx.token.balanceOf(acceptor);
+    expect(fromWei(balance)).to.equal('98');
+
+    const sponsorBalance = await ctx.token.balanceOf(relayer);
+    expect(fromWei(sponsorBalance)).to.equal('2');
+  });
+
+  it('should call the hook contract when the stealth receiver withdraws via meta tx to the hook contract', async () => {
+    await mintAndSendToken(sender, metaWallet.address, '100');
+
+    const { v, r, s } = await signMetaWithdrawal(
+      metaWallet,
+      ctx.chainId,
+      ctx.version,
+      ctx.hook.address,
+      ctx.token.address,
+      relayer,
+      relayerTokenFee,
+      ctx.hook.address,
+      '0xbeefc0ffee'
+    );
+
+    const receipt = await ctx.umbra.withdrawTokenAndCallOnBehalf(
+      metaWallet.address,
+      ctx.hook.address,
+      ctx.token.address,
+      relayer,
+      relayerTokenFee,
+      ctx.hook.address,
+      '0xbeefc0ffee',
+      v,
+      r,
+      s,
+      { from: relayer }
+    );
+
+    const callData = await ctx.hook.lastCallData();
+
+    expect(fromWei(callData.amount)).to.equal('98');
+    expect(callData.stealthAddr).to.equal(metaWallet.address);
+    expect(callData.acceptor).to.equal(ctx.hook.address);
+    expect(callData.tokenAddr).to.equal(ctx.token.address);
+    expect(callData.sponsor).to.equal(relayer);
+    expect(fromWei(callData.sponsorFee)).to.equal('2');
+    expect(callData.data).to.equal('0xbeefc0ffee');
+
+    const balance = await ctx.token.balanceOf(ctx.hook.address);
+    expect(fromWei(balance)).to.equal('98');
+
+    const sponsorBalance = await ctx.token.balanceOf(relayer);
+    expect(fromWei(sponsorBalance)).to.equal('2');
+  });
+
+  it('should fail if the relayer sends the wrong hook address', async () => {
+    await mintAndSendToken(sender, metaWallet.address, '100');
+
+    const { v, r, s } = await signMetaWithdrawal(
+      metaWallet,
+      ctx.chainId,
+      ctx.version,
+      acceptor,
+      ctx.token.address,
+      relayer,
+      relayerTokenFee,
+      ctx.hook.address,
+      '0xbeefc0ffee'
+    );
+
+    await expectRevert(
+      ctx.umbra.withdrawTokenAndCallOnBehalf(
+        metaWallet.address,
+        acceptor,
+        ctx.token.address,
+        relayer,
+        relayerTokenFee,
+        ethers.Wallet.createRandom().address, // this should be the hook address
+        '0xbeefc0ffee',
+        v,
+        r,
+        s,
+        { from: relayer }
+      ),
+      'Umbra: Invalid Signature'
+    );
+  });
+
+  it('should fail if the relayer sends the wrong hook call cata', async () => {
+    await mintAndSendToken(sender, metaWallet.address, '100');
+
+    const { v, r, s } = await signMetaWithdrawal(
+      metaWallet,
+      ctx.chainId,
+      ctx.version,
+      acceptor,
+      ctx.token.address,
+      relayer,
+      relayerTokenFee,
+      ctx.hook.address,
+      '0xbeefc0ffee'
+    );
+
+    await expectRevert(
+      ctx.umbra.withdrawTokenAndCallOnBehalf(
+        metaWallet.address,
+        acceptor,
+        ctx.token.address,
+        relayer,
+        relayerTokenFee,
+        ctx.hook.address,
+        '0xbeefcafe', // this should be 0xbeefc0ffee
+        v,
+        r,
+        s,
+        { from: relayer }
+      ),
+      'Umbra: Invalid Signature'
+    );
   });
 });

--- a/contracts/test/umbra-hook-test.js
+++ b/contracts/test/umbra-hook-test.js
@@ -68,340 +68,346 @@ describe('Umbra Hooks', () => {
     expect(ctx.hook.address.length).to.equal(42);
   });
 
-  it('should call the hook contract when the stealth receiver withdraws directly', async () => {
-    await mintAndSendToken(sender, receiver, '100');
+  describe('Direct withdrawal + hooks', async () => {
+    it('should call the hook contract when the stealth receiver withdraws directly', async () => {
+      await mintAndSendToken(sender, receiver, '100');
 
-    await ctx.umbra.withdrawTokenAndCall(acceptor, ctx.token.address, ctx.hook.address, '0xbeefc0ffee', {
-      from: receiver,
+      await ctx.umbra.withdrawTokenAndCall(acceptor, ctx.token.address, ctx.hook.address, '0xbeefc0ffee', {
+        from: receiver,
+      });
+
+      const callData = await ctx.hook.lastCallData();
+
+      expect(fromWei(callData.amount)).to.equal('100');
+      expect(callData.stealthAddr).to.equal(receiver);
+      expect(callData.acceptor).to.equal(acceptor);
+      expect(callData.tokenAddr).to.equal(ctx.token.address);
+      expect(callData.sponsor).to.equal(AddressZero);
+      expect(fromWei(callData.sponsorFee)).to.equal('0');
+      expect(callData.data).to.equal('0xbeefc0ffee');
+
+      const balance = await ctx.token.balanceOf(acceptor);
+      expect(fromWei(balance)).to.equal('100');
     });
 
-    const callData = await ctx.hook.lastCallData();
+    it('should call the hook contract when the stealth receiver withdraws directly with empty data', async () => {
+      await mintAndSendToken(sender, receiver, '100');
 
-    expect(fromWei(callData.amount)).to.equal('100');
-    expect(callData.stealthAddr).to.equal(receiver);
-    expect(callData.acceptor).to.equal(acceptor);
-    expect(callData.tokenAddr).to.equal(ctx.token.address);
-    expect(callData.sponsor).to.equal(AddressZero);
-    expect(fromWei(callData.sponsorFee)).to.equal('0');
-    expect(callData.data).to.equal('0xbeefc0ffee');
+      await ctx.umbra.withdrawTokenAndCall(acceptor, ctx.token.address, ctx.hook.address, [], {
+        from: receiver,
+      });
 
-    const balance = await ctx.token.balanceOf(acceptor);
-    expect(fromWei(balance)).to.equal('100');
-  });
+      const callData = await ctx.hook.lastCallData();
 
-  it('should call the hook contract when the stealth receiver withdraws directly with empty data', async () => {
-    await mintAndSendToken(sender, receiver, '100');
+      expect(fromWei(callData.amount)).to.equal('100');
+      expect(callData.stealthAddr).to.equal(receiver);
+      expect(callData.acceptor).to.equal(acceptor);
+      expect(callData.tokenAddr).to.equal(ctx.token.address);
+      expect(callData.sponsor).to.equal(AddressZero);
+      expect(fromWei(callData.sponsorFee)).to.equal('0');
+      expect(callData.data).to.equal(null);
 
-    await ctx.umbra.withdrawTokenAndCall(acceptor, ctx.token.address, ctx.hook.address, [], {
-      from: receiver,
+      const balance = await ctx.token.balanceOf(acceptor);
+      expect(fromWei(balance)).to.equal('100');
     });
 
-    const callData = await ctx.hook.lastCallData();
+    it('should call the hook contract when the stealth receiver withdraws directly to the hook contract', async () => {
+      await mintAndSendToken(sender, receiver, '100');
 
-    expect(fromWei(callData.amount)).to.equal('100');
-    expect(callData.stealthAddr).to.equal(receiver);
-    expect(callData.acceptor).to.equal(acceptor);
-    expect(callData.tokenAddr).to.equal(ctx.token.address);
-    expect(callData.sponsor).to.equal(AddressZero);
-    expect(fromWei(callData.sponsorFee)).to.equal('0');
-    expect(callData.data).to.equal(null);
+      await ctx.umbra.withdrawTokenAndCall(ctx.hook.address, ctx.token.address, ctx.hook.address, '0xbeefc0ffee', {
+        from: receiver,
+      });
 
-    const balance = await ctx.token.balanceOf(acceptor);
-    expect(fromWei(balance)).to.equal('100');
-  });
+      const callData = await ctx.hook.lastCallData();
 
-  it('should call the hook contract when the stealth receiver withdraws directly to the hook contract', async () => {
-    await mintAndSendToken(sender, receiver, '100');
+      expect(fromWei(callData.amount)).to.equal('100');
+      expect(callData.stealthAddr).to.equal(receiver);
+      expect(callData.acceptor).to.equal(ctx.hook.address);
+      expect(callData.tokenAddr).to.equal(ctx.token.address);
+      expect(callData.sponsor).to.equal(AddressZero);
+      expect(fromWei(callData.sponsorFee)).to.equal('0');
+      expect(callData.data).to.equal('0xbeefc0ffee');
 
-    await ctx.umbra.withdrawTokenAndCall(ctx.hook.address, ctx.token.address, ctx.hook.address, '0xbeefc0ffee', {
-      from: receiver,
+      const balance = await ctx.token.balanceOf(ctx.hook.address);
+      expect(fromWei(balance)).to.equal('100');
     });
 
-    const callData = await ctx.hook.lastCallData();
+    it('should not call the hook when the stealth receiver withdraws directly if the hook address is 0', async () => {
+      await mintAndSendToken(sender, receiver, '100');
 
-    expect(fromWei(callData.amount)).to.equal('100');
-    expect(callData.stealthAddr).to.equal(receiver);
-    expect(callData.acceptor).to.equal(ctx.hook.address);
-    expect(callData.tokenAddr).to.equal(ctx.token.address);
-    expect(callData.sponsor).to.equal(AddressZero);
-    expect(fromWei(callData.sponsorFee)).to.equal('0');
-    expect(callData.data).to.equal('0xbeefc0ffee');
+      await ctx.umbra.withdrawTokenAndCall(acceptor, ctx.token.address, AddressZero, '0xbeefc0ffee', {
+        from: receiver,
+      });
 
-    const balance = await ctx.token.balanceOf(ctx.hook.address);
-    expect(fromWei(balance)).to.equal('100');
-  });
+      const callData = await ctx.hook.lastCallData();
 
-  it('should not call the hook when the stealth receiver withdraws directly if the hook address is 0', async () => {
-    await mintAndSendToken(sender, receiver, '100');
+      // call data in the mock trigger should still be zeroes
+      expect(fromWei(callData.amount)).to.equal('0');
+      expect(callData.stealthAddr).to.equal(AddressZero);
+      expect(callData.acceptor).to.equal(AddressZero);
+      expect(callData.tokenAddr).to.equal(AddressZero);
+      expect(callData.sponsor).to.equal(AddressZero);
+      expect(fromWei(callData.sponsorFee)).to.equal('0');
+      expect(callData.data).to.equal(null);
 
-    await ctx.umbra.withdrawTokenAndCall(acceptor, ctx.token.address, AddressZero, '0xbeefc0ffee', {
-      from: receiver,
+      // the withdrawal transfer should still work
+      const balance = await ctx.token.balanceOf(acceptor);
+      expect(fromWei(balance)).to.equal('100');
     });
-
-    const callData = await ctx.hook.lastCallData();
-
-    // call data in the mock trigger should still be zeroes
-    expect(fromWei(callData.amount)).to.equal('0');
-    expect(callData.stealthAddr).to.equal(AddressZero);
-    expect(callData.acceptor).to.equal(AddressZero);
-    expect(callData.tokenAddr).to.equal(AddressZero);
-    expect(callData.sponsor).to.equal(AddressZero);
-    expect(fromWei(callData.sponsorFee)).to.equal('0');
-    expect(callData.data).to.equal(null);
-
-    // the withdrawal  transfer should still work
-    const balance = await ctx.token.balanceOf(acceptor);
-    expect(fromWei(balance)).to.equal('100');
   });
 
-  it('should call the hook contract when the stealth receiver withdraws via meta tx', async () => {
-    await mintAndSendToken(sender, metaWallet.address, '100');
+  describe('Meta withdrawal + hooks', async () => {
+    it('should call the hook contract when the stealth receiver withdraws via meta tx', async () => {
+      await mintAndSendToken(sender, metaWallet.address, '100');
 
-    const { v, r, s } = await signMetaWithdrawal(
-      metaWallet,
-      ctx.chainId,
-      ctx.version,
-      acceptor,
-      ctx.token.address,
-      relayer,
-      relayerTokenFee,
-      ctx.hook.address,
-      '0xbeefc0ffee'
-    );
-
-    const receipt = await ctx.umbra.withdrawTokenAndCallOnBehalf(
-      metaWallet.address,
-      acceptor,
-      ctx.token.address,
-      relayer,
-      relayerTokenFee,
-      ctx.hook.address,
-      '0xbeefc0ffee',
-      v,
-      r,
-      s,
-      { from: relayer }
-    );
-
-    const callData = await ctx.hook.lastCallData();
-
-    expect(fromWei(callData.amount)).to.equal('98');
-    expect(callData.stealthAddr).to.equal(metaWallet.address);
-    expect(callData.acceptor).to.equal(acceptor);
-    expect(callData.tokenAddr).to.equal(ctx.token.address);
-    expect(callData.sponsor).to.equal(relayer);
-    expect(fromWei(callData.sponsorFee)).to.equal('2');
-    expect(callData.data).to.equal('0xbeefc0ffee');
-
-    const balance = await ctx.token.balanceOf(acceptor);
-    expect(fromWei(balance)).to.equal('98');
-
-    const sponsorBalance = await ctx.token.balanceOf(relayer);
-    expect(fromWei(sponsorBalance)).to.equal('2');
-  });
-
-  it('should call the hook contract when the stealth receiver withdraws via meta tx with empty data', async () => {
-    await mintAndSendToken(sender, metaWallet.address, '100');
-
-    const { v, r, s } = await signMetaWithdrawal(
-      metaWallet,
-      ctx.chainId,
-      ctx.version,
-      acceptor,
-      ctx.token.address,
-      relayer,
-      relayerTokenFee,
-      ctx.hook.address,
-      []
-    );
-
-    const receipt = await ctx.umbra.withdrawTokenAndCallOnBehalf(
-      metaWallet.address,
-      acceptor,
-      ctx.token.address,
-      relayer,
-      relayerTokenFee,
-      ctx.hook.address,
-      [],
-      v,
-      r,
-      s,
-      { from: relayer }
-    );
-
-    const callData = await ctx.hook.lastCallData();
-
-    expect(fromWei(callData.amount)).to.equal('98');
-    expect(callData.stealthAddr).to.equal(metaWallet.address);
-    expect(callData.acceptor).to.equal(acceptor);
-    expect(callData.tokenAddr).to.equal(ctx.token.address);
-    expect(callData.sponsor).to.equal(relayer);
-    expect(fromWei(callData.sponsorFee)).to.equal('2');
-    expect(callData.data).to.equal(null);
-
-    const balance = await ctx.token.balanceOf(acceptor);
-    expect(fromWei(balance)).to.equal('98');
-
-    const sponsorBalance = await ctx.token.balanceOf(relayer);
-    expect(fromWei(sponsorBalance)).to.equal('2');
-  });
-
-  it('should not call the hook if the hook contract is 0 when the stealth receiver withdraws via meta tx', async () => {
-    await mintAndSendToken(sender, metaWallet.address, '100');
-
-    const { v, r, s } = await signMetaWithdrawal(
-      metaWallet,
-      ctx.chainId,
-      ctx.version,
-      acceptor,
-      ctx.token.address,
-      relayer,
-      relayerTokenFee,
-      AddressZero,
-      '0xbeefc0ffee'
-    );
-
-    const receipt = await ctx.umbra.withdrawTokenAndCallOnBehalf(
-      metaWallet.address,
-      acceptor,
-      ctx.token.address,
-      relayer,
-      relayerTokenFee,
-      AddressZero,
-      '0xbeefc0ffee',
-      v,
-      r,
-      s,
-      { from: relayer }
-    );
-
-    const callData = await ctx.hook.lastCallData();
-
-    // call data in the mock trigger should still be zeroes
-    expect(fromWei(callData.amount)).to.equal('0');
-    expect(callData.stealthAddr).to.equal(AddressZero);
-    expect(callData.acceptor).to.equal(AddressZero);
-    expect(callData.tokenAddr).to.equal(AddressZero);
-    expect(callData.sponsor).to.equal(AddressZero);
-    expect(fromWei(callData.sponsorFee)).to.equal('0');
-    expect(callData.data).to.equal(null);
-
-    const balance = await ctx.token.balanceOf(acceptor);
-    expect(fromWei(balance)).to.equal('98');
-
-    const sponsorBalance = await ctx.token.balanceOf(relayer);
-    expect(fromWei(sponsorBalance)).to.equal('2');
-  });
-
-  it('should call the hook contract when the stealth receiver withdraws via meta tx to the hook contract', async () => {
-    await mintAndSendToken(sender, metaWallet.address, '100');
-
-    const { v, r, s } = await signMetaWithdrawal(
-      metaWallet,
-      ctx.chainId,
-      ctx.version,
-      ctx.hook.address,
-      ctx.token.address,
-      relayer,
-      relayerTokenFee,
-      ctx.hook.address,
-      '0xbeefc0ffee'
-    );
-
-    const receipt = await ctx.umbra.withdrawTokenAndCallOnBehalf(
-      metaWallet.address,
-      ctx.hook.address,
-      ctx.token.address,
-      relayer,
-      relayerTokenFee,
-      ctx.hook.address,
-      '0xbeefc0ffee',
-      v,
-      r,
-      s,
-      { from: relayer }
-    );
-
-    const callData = await ctx.hook.lastCallData();
-
-    expect(fromWei(callData.amount)).to.equal('98');
-    expect(callData.stealthAddr).to.equal(metaWallet.address);
-    expect(callData.acceptor).to.equal(ctx.hook.address);
-    expect(callData.tokenAddr).to.equal(ctx.token.address);
-    expect(callData.sponsor).to.equal(relayer);
-    expect(fromWei(callData.sponsorFee)).to.equal('2');
-    expect(callData.data).to.equal('0xbeefc0ffee');
-
-    const balance = await ctx.token.balanceOf(ctx.hook.address);
-    expect(fromWei(balance)).to.equal('98');
-
-    const sponsorBalance = await ctx.token.balanceOf(relayer);
-    expect(fromWei(sponsorBalance)).to.equal('2');
-  });
-
-  it('should fail if the relayer sends the wrong hook address', async () => {
-    await mintAndSendToken(sender, metaWallet.address, '100');
-
-    const { v, r, s } = await signMetaWithdrawal(
-      metaWallet,
-      ctx.chainId,
-      ctx.version,
-      acceptor,
-      ctx.token.address,
-      relayer,
-      relayerTokenFee,
-      ctx.hook.address,
-      '0xbeefc0ffee'
-    );
-
-    await expectRevert(
-      ctx.umbra.withdrawTokenAndCallOnBehalf(
-        metaWallet.address,
+      const { v, r, s } = await signMetaWithdrawal(
+        metaWallet,
+        ctx.chainId,
+        ctx.version,
         acceptor,
         ctx.token.address,
         relayer,
         relayerTokenFee,
-        ethers.Wallet.createRandom().address, // this should be the hook address
-        '0xbeefc0ffee',
-        v,
-        r,
-        s,
-        { from: relayer }
-      ),
-      'Umbra: Invalid Signature'
-    );
-  });
+        ctx.hook.address,
+        '0xbeefc0ffee'
+      );
 
-  it('should fail if the relayer sends the wrong hook call cata', async () => {
-    await mintAndSendToken(sender, metaWallet.address, '100');
-
-    const { v, r, s } = await signMetaWithdrawal(
-      metaWallet,
-      ctx.chainId,
-      ctx.version,
-      acceptor,
-      ctx.token.address,
-      relayer,
-      relayerTokenFee,
-      ctx.hook.address,
-      '0xbeefc0ffee'
-    );
-
-    await expectRevert(
-      ctx.umbra.withdrawTokenAndCallOnBehalf(
+      const receipt = await ctx.umbra.withdrawTokenAndCallOnBehalf(
         metaWallet.address,
         acceptor,
         ctx.token.address,
         relayer,
         relayerTokenFee,
         ctx.hook.address,
-        '0xbeefcafe', // this should be 0xbeefc0ffee
+        '0xbeefc0ffee',
         v,
         r,
         s,
         { from: relayer }
-      ),
-      'Umbra: Invalid Signature'
-    );
+      );
+
+      const callData = await ctx.hook.lastCallData();
+
+      expect(fromWei(callData.amount)).to.equal('98');
+      expect(callData.stealthAddr).to.equal(metaWallet.address);
+      expect(callData.acceptor).to.equal(acceptor);
+      expect(callData.tokenAddr).to.equal(ctx.token.address);
+      expect(callData.sponsor).to.equal(relayer);
+      expect(fromWei(callData.sponsorFee)).to.equal('2');
+      expect(callData.data).to.equal('0xbeefc0ffee');
+
+      const balance = await ctx.token.balanceOf(acceptor);
+      expect(fromWei(balance)).to.equal('98');
+
+      const sponsorBalance = await ctx.token.balanceOf(relayer);
+      expect(fromWei(sponsorBalance)).to.equal('2');
+    });
+
+    it('should call the hook contract when the stealth receiver withdraws via meta tx with empty data', async () => {
+      await mintAndSendToken(sender, metaWallet.address, '100');
+
+      const { v, r, s } = await signMetaWithdrawal(
+        metaWallet,
+        ctx.chainId,
+        ctx.version,
+        acceptor,
+        ctx.token.address,
+        relayer,
+        relayerTokenFee,
+        ctx.hook.address,
+        []
+      );
+
+      const receipt = await ctx.umbra.withdrawTokenAndCallOnBehalf(
+        metaWallet.address,
+        acceptor,
+        ctx.token.address,
+        relayer,
+        relayerTokenFee,
+        ctx.hook.address,
+        [],
+        v,
+        r,
+        s,
+        { from: relayer }
+      );
+
+      const callData = await ctx.hook.lastCallData();
+
+      expect(fromWei(callData.amount)).to.equal('98');
+      expect(callData.stealthAddr).to.equal(metaWallet.address);
+      expect(callData.acceptor).to.equal(acceptor);
+      expect(callData.tokenAddr).to.equal(ctx.token.address);
+      expect(callData.sponsor).to.equal(relayer);
+      expect(fromWei(callData.sponsorFee)).to.equal('2');
+      expect(callData.data).to.equal(null);
+
+      const balance = await ctx.token.balanceOf(acceptor);
+      expect(fromWei(balance)).to.equal('98');
+
+      const sponsorBalance = await ctx.token.balanceOf(relayer);
+      expect(fromWei(sponsorBalance)).to.equal('2');
+    });
+
+    it('should not call the hook if the hook contract is 0 when the stealth receiver withdraws via meta tx', async () => {
+      await mintAndSendToken(sender, metaWallet.address, '100');
+
+      const { v, r, s } = await signMetaWithdrawal(
+        metaWallet,
+        ctx.chainId,
+        ctx.version,
+        acceptor,
+        ctx.token.address,
+        relayer,
+        relayerTokenFee,
+        AddressZero,
+        '0xbeefc0ffee'
+      );
+
+      const receipt = await ctx.umbra.withdrawTokenAndCallOnBehalf(
+        metaWallet.address,
+        acceptor,
+        ctx.token.address,
+        relayer,
+        relayerTokenFee,
+        AddressZero,
+        '0xbeefc0ffee',
+        v,
+        r,
+        s,
+        { from: relayer }
+      );
+
+      const callData = await ctx.hook.lastCallData();
+
+      // call data in the mock trigger should still be zeroes
+      expect(fromWei(callData.amount)).to.equal('0');
+      expect(callData.stealthAddr).to.equal(AddressZero);
+      expect(callData.acceptor).to.equal(AddressZero);
+      expect(callData.tokenAddr).to.equal(AddressZero);
+      expect(callData.sponsor).to.equal(AddressZero);
+      expect(fromWei(callData.sponsorFee)).to.equal('0');
+      expect(callData.data).to.equal(null);
+
+      const balance = await ctx.token.balanceOf(acceptor);
+      expect(fromWei(balance)).to.equal('98');
+
+      const sponsorBalance = await ctx.token.balanceOf(relayer);
+      expect(fromWei(sponsorBalance)).to.equal('2');
+    });
+
+    it('should call the hook contract when the stealth receiver withdraws via meta tx to the hook contract', async () => {
+      await mintAndSendToken(sender, metaWallet.address, '100');
+
+      const { v, r, s } = await signMetaWithdrawal(
+        metaWallet,
+        ctx.chainId,
+        ctx.version,
+        ctx.hook.address,
+        ctx.token.address,
+        relayer,
+        relayerTokenFee,
+        ctx.hook.address,
+        '0xbeefc0ffee'
+      );
+
+      const receipt = await ctx.umbra.withdrawTokenAndCallOnBehalf(
+        metaWallet.address,
+        ctx.hook.address,
+        ctx.token.address,
+        relayer,
+        relayerTokenFee,
+        ctx.hook.address,
+        '0xbeefc0ffee',
+        v,
+        r,
+        s,
+        { from: relayer }
+      );
+
+      const callData = await ctx.hook.lastCallData();
+
+      expect(fromWei(callData.amount)).to.equal('98');
+      expect(callData.stealthAddr).to.equal(metaWallet.address);
+      expect(callData.acceptor).to.equal(ctx.hook.address);
+      expect(callData.tokenAddr).to.equal(ctx.token.address);
+      expect(callData.sponsor).to.equal(relayer);
+      expect(fromWei(callData.sponsorFee)).to.equal('2');
+      expect(callData.data).to.equal('0xbeefc0ffee');
+
+      const balance = await ctx.token.balanceOf(ctx.hook.address);
+      expect(fromWei(balance)).to.equal('98');
+
+      const sponsorBalance = await ctx.token.balanceOf(relayer);
+      expect(fromWei(sponsorBalance)).to.equal('2');
+    });
+  });
+
+  describe('Meta withdrawal + hooks + dishonest relayer', async () => {
+    it('should fail if the relayer sends the wrong hook address', async () => {
+      await mintAndSendToken(sender, metaWallet.address, '100');
+
+      const { v, r, s } = await signMetaWithdrawal(
+        metaWallet,
+        ctx.chainId,
+        ctx.version,
+        acceptor,
+        ctx.token.address,
+        relayer,
+        relayerTokenFee,
+        ctx.hook.address,
+        '0xbeefc0ffee'
+      );
+
+      await expectRevert(
+        ctx.umbra.withdrawTokenAndCallOnBehalf(
+          metaWallet.address,
+          acceptor,
+          ctx.token.address,
+          relayer,
+          relayerTokenFee,
+          ethers.Wallet.createRandom().address, // this should be the hook address
+          '0xbeefc0ffee',
+          v,
+          r,
+          s,
+          { from: relayer }
+        ),
+        'Umbra: Invalid Signature'
+      );
+    });
+
+    it('should fail if the relayer sends the wrong hook call cata', async () => {
+      await mintAndSendToken(sender, metaWallet.address, '100');
+
+      const { v, r, s } = await signMetaWithdrawal(
+        metaWallet,
+        ctx.chainId,
+        ctx.version,
+        acceptor,
+        ctx.token.address,
+        relayer,
+        relayerTokenFee,
+        ctx.hook.address,
+        '0xbeefc0ffee'
+      );
+
+      await expectRevert(
+        ctx.umbra.withdrawTokenAndCallOnBehalf(
+          metaWallet.address,
+          acceptor,
+          ctx.token.address,
+          relayer,
+          relayerTokenFee,
+          ctx.hook.address,
+          '0xbeefcafe', // this should be 0xbeefc0ffee
+          v,
+          r,
+          s,
+          { from: relayer }
+        ),
+        'Umbra: Invalid Signature'
+      );
+    });
   });
 });

--- a/contracts/test/umbra-hook-test.js
+++ b/contracts/test/umbra-hook-test.js
@@ -1,0 +1,145 @@
+const { ethers, web3, artifacts } = require('hardhat');
+const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
+const { expect } = require('chai');
+const { argumentBytes } = require('./sample-data');
+const { sumTokenAmounts, signMetaWithdrawal } = require('./utils');
+
+const Umbra = artifacts.require('Umbra');
+const TestToken = artifacts.require('TestToken');
+const MockHook = artifacts.require('MockHook');
+const { toWei, fromWei, BN } = web3.utils;
+const AddressZero = ethers.constants.AddressZero;
+
+describe('Umbra Hooks', () => {
+  const ctx = {};
+  let owner, sender, receiver, acceptor;
+
+  const toll = toWei('0.01', 'ether');
+
+  // helper function to mint test tokens
+  const mintToken = async (toAddr, amount) => {
+    await ctx.token.mint(toAddr, toWei(amount));
+  };
+
+  // helper function to send test tokens to stealth address
+  const sendToken = async (fromAddr, stealthAddr, amount) => {
+    const toll = await ctx.umbra.toll();
+    const weiAmount = toWei(amount);
+
+    await ctx.token.approve(ctx.umbra.address, weiAmount, { from: fromAddr });
+
+    await ctx.umbra.sendToken(stealthAddr, ctx.token.address, weiAmount, ...argumentBytes, {
+      from: fromAddr,
+      value: toll,
+    });
+  };
+
+  // helper function to mint and send tokens to steatlh address
+  const mintAndSendToken = async (fromAddr, stealthAddr, amount) => {
+    await mintToken(fromAddr, amount);
+    await sendToken(fromAddr, stealthAddr, amount);
+  };
+
+  beforeEach(async () => {
+    [owner, sender, receiver, acceptor] = await web3.eth.getAccounts();
+
+    ctx.umbra = await Umbra.new(toll, owner, owner, { from: owner });
+    ctx.token = await TestToken.new('TestToken', 'TT');
+    ctx.hook = await MockHook.new();
+  });
+
+  it('should see the deployed Umbra contract', async () => {
+    expect(ctx.umbra.address.startsWith('0x')).to.be.true;
+    expect(ctx.umbra.address.length).to.equal(42);
+    expect(ctx.token.address.startsWith('0x')).to.be.true;
+    expect(ctx.token.address.length).to.equal(42);
+    expect(ctx.hook.address.startsWith('0x')).to.be.true;
+    expect(ctx.hook.address.length).to.equal(42);
+  });
+
+  it('should call the hook contract when the stealth receiver withdraws directly', async () => {
+    await mintAndSendToken(sender, receiver, '100');
+
+    await ctx.umbra.withdrawTokenAndCall(acceptor, ctx.token.address, ctx.hook.address, '0xbeefc0ffee', {
+      from: receiver,
+    });
+
+    const callData = await ctx.hook.lastCallData();
+
+    expect(fromWei(callData.amount)).to.equal('100');
+    expect(callData.stealthAddr).to.equal(receiver);
+    expect(callData.acceptor).to.equal(acceptor);
+    expect(callData.tokenAddr).to.equal(ctx.token.address);
+    expect(callData.sponsor).to.equal(AddressZero);
+    expect(callData.sponsorFee.toString()).to.equal('0');
+    expect(callData.data).to.equal('0xbeefc0ffee');
+
+    const balance = await ctx.token.balanceOf(acceptor);
+    expect(fromWei(balance)).to.equal('100');
+  });
+
+  it('should call the hook contract when the stealth receiver withdraws directly with empty data', async () => {
+    await mintAndSendToken(sender, receiver, '100');
+
+    await ctx.umbra.withdrawTokenAndCall(acceptor, ctx.token.address, ctx.hook.address, [], {
+      from: receiver,
+    });
+
+    const callData = await ctx.hook.lastCallData();
+
+    expect(fromWei(callData.amount)).to.equal('100');
+    expect(callData.stealthAddr).to.equal(receiver);
+    expect(callData.acceptor).to.equal(acceptor);
+    expect(callData.tokenAddr).to.equal(ctx.token.address);
+    expect(callData.sponsor).to.equal(AddressZero);
+    expect(callData.sponsorFee.toString()).to.equal('0');
+    expect(callData.data).to.equal(null);
+
+    const balance = await ctx.token.balanceOf(acceptor);
+    expect(fromWei(balance)).to.equal('100');
+  });
+
+  it('should not call the hook if the hook address is 0', async () => {
+    await mintAndSendToken(sender, receiver, '100');
+
+    await ctx.umbra.withdrawTokenAndCall(acceptor, ctx.token.address, AddressZero, '0xbeefc0ffee', {
+      from: receiver,
+    });
+
+    const callData = await ctx.hook.lastCallData();
+
+    // call data in the mock trigger is just still zeroes
+    expect(fromWei(callData.amount)).to.equal('0');
+    expect(callData.stealthAddr).to.equal(AddressZero);
+    expect(callData.acceptor).to.equal(AddressZero);
+    expect(callData.tokenAddr).to.equal(AddressZero);
+    expect(callData.sponsor).to.equal(AddressZero);
+    expect(callData.sponsorFee.toString()).to.equal('0');
+    expect(callData.data).to.equal(null);
+
+    // the withdrawal  transfer should still work
+    const balance = await ctx.token.balanceOf(acceptor);
+    expect(fromWei(balance)).to.equal('100');
+  });
+
+  it('should call the hook contract when the stealth receiver withdraws directly to the hook contract', async () => {
+    await mintAndSendToken(sender, receiver, '100');
+
+    await ctx.umbra.withdrawTokenAndCall(ctx.hook.address, ctx.token.address, ctx.hook.address, '0xbeefc0ffee', {
+      from: receiver,
+    });
+
+    const callData = await ctx.hook.lastCallData();
+
+    expect(fromWei(callData.amount)).to.equal('100');
+    expect(callData.stealthAddr).to.equal(receiver);
+    expect(callData.acceptor).to.equal(ctx.hook.address);
+    expect(callData.tokenAddr).to.equal(ctx.token.address);
+    expect(callData.sponsor).to.equal(AddressZero);
+    expect(callData.sponsorFee.toString()).to.equal('0');
+    expect(callData.data).to.equal('0xbeefc0ffee');
+
+    const balance = await ctx.token.balanceOf(ctx.hook.address);
+    expect(fromWei(balance)).to.equal('100');
+  });
+});

--- a/contracts/test/umbra-test.js
+++ b/contracts/test/umbra-test.js
@@ -186,7 +186,7 @@ describe('Umbra', () => {
   it('should not let the eth receiver withdraw tokens', async () => {
     await expectRevert(
       ctx.umbra.withdrawToken(acceptor, ctx.token.address, { from: receiver1 }),
-      'Umbra: No tokens available for withdrawal'
+      'Umbra: No balance to withdraw or fee exceeds balance'
     );
   });
 
@@ -309,7 +309,7 @@ describe('Umbra', () => {
   it('should not allow a non-receiver to withdraw tokens', async () => {
     await expectRevert(
       ctx.umbra.withdrawToken(acceptor, ctx.token.address, { from: other }),
-      'Umbra: No tokens available for withdrawal'
+      'Umbra: No balance to withdraw or fee exceeds balance'
     );
   });
 
@@ -331,7 +331,7 @@ describe('Umbra', () => {
   it('should not allow a receiver to withdraw their tokens twice', async () => {
     await expectRevert(
       ctx.umbra.withdrawToken(acceptor, ctx.token.address, { from: receiver2 }),
-      'Umbra: No tokens available for withdraw'
+      'Umbra: No balance to withdraw or fee exceeds balance'
     );
   });
 
@@ -391,7 +391,7 @@ describe('Umbra', () => {
   it('should revert on meta withdrawal if the fee is more than the amount', async () => {
     const bigFee = sumTokenAmounts([metaTokenTotal, '100']);
 
-    const { v, r, s } = await signMetaWithdrawal(metaWallet, ctx.chainId, ctx.version, metaAcceptor, ctx.token.address, relayer, relayerTokenFee);
+    const { v, r, s } = await signMetaWithdrawal(metaWallet, ctx.chainId, ctx.version, metaAcceptor, ctx.token.address, relayer, bigFee);
 
     await expectRevert(
       ctx.umbra.withdrawTokenOnBehalf(metaWallet.address, metaAcceptor, ctx.token.address, relayer, bigFee, v, r, s, {

--- a/contracts/test/utils.js
+++ b/contracts/test/utils.js
@@ -3,6 +3,7 @@ const ethers = require('ethers');
 
 const { BN } = web3.utils;
 const { keccak256, defaultAbiCoder, arrayify, splitSignature } = ethers.utils;
+const { AddressZero } = ethers.constants;
 
 /**
  * Sum token amounts sent as strings and return a string
@@ -24,13 +25,25 @@ const sumTokenAmounts = (amounts) => {
  * @param {string} token Address of token being withdrawn
  * @param {string} sponsor Address of relayer
  * @param {number|string} fee Amount sent to sponsor
+ * @param {string} hook Address of post withdraw hook contract
+ * @param {string|array} data Call data to be past to post withdraw hook
  */
-const signMetaWithdrawal = async (signer, chainId, version, acceptor, token, sponsor, fee) => {
+const signMetaWithdrawal = async (
+  signer,
+  chainId,
+  version,
+  acceptor,
+  token,
+  sponsor,
+  fee,
+  hook = AddressZero,
+  data = []
+) => {
   const digest = keccak256(
     defaultAbiCoder.encode(
-      ['uint256', 'string', 'address', 'address', 'address', 'uint256'],
-      [chainId, version, acceptor, token, sponsor, fee],
-    ),
+      ['uint256', 'string', 'address', 'address', 'address', 'uint256', 'address', 'bytes'],
+      [chainId, version, acceptor, token, sponsor, fee, hook, data]
+    )
   );
 
   const rawSig = await signer.signMessage(arrayify(digest));

--- a/contracts/test/utils.js
+++ b/contracts/test/utils.js
@@ -37,7 +37,7 @@ const signMetaWithdrawal = async (
   sponsor,
   fee,
   hook = AddressZero,
-  data = []
+  data = '0x'
 ) => {
   const digest = keccak256(
     defaultAbiCoder.encode(

--- a/umbra-js/src/classes/Umbra.ts
+++ b/umbra-js/src/classes/Umbra.ts
@@ -432,9 +432,9 @@ export class Umbra {
     if (data === null) {
       // Empty data should passed as an empty array to encode
       dataArg = [];
-    } else if (typeof data !== 'string' || !data.startsWith('0x')) {
+    } else if (typeof data !== 'string' || !isHexString(data)) {
       // Validate the data string
-      throw new Error('Data string must be in hex form with 0x prefix');
+      throw new Error('Data string must be null or in hex form with 0x prefix');
     } else {
       dataArg = data;
     }

--- a/umbra-js/src/classes/Umbra.ts
+++ b/umbra-js/src/classes/Umbra.ts
@@ -415,7 +415,7 @@ export class Umbra {
     sponsor: string,
     sponsorFee: BigNumberish,
     hook: string = AddressZero,
-    data: string | null = null
+    data = '0x'
   ) {
     // Validate addresses
     acceptor = getAddress(acceptor);
@@ -428,22 +428,16 @@ export class Umbra {
       throw new Error(`Invalid chainId provided in chainConfig. Got '${chainId}'`);
     }
 
-    let dataArg;
-    if (data === null) {
-      // Empty data should passed as an empty array to encode
-      dataArg = [];
-    } else if (typeof data !== 'string' || !isHexString(data)) {
-      // Validate the data string
+    // Validate the data string
+    if (typeof data !== 'string' || !isHexString(data)) {
       throw new Error('Data string must be null or in hex form with 0x prefix');
-    } else {
-      dataArg = data;
     }
 
     const stealthWallet = new Wallet(spendingPrivateKey);
     const digest = keccak256(
       defaultAbiCoder.encode(
         ['uint256', 'string', 'address', 'address', 'address', 'uint256', 'address', 'bytes'],
-        [chainId, version, acceptor, token, sponsor, sponsorFee, hook, dataArg]
+        [chainId, version, acceptor, token, sponsor, sponsorFee, hook, data]
       )
     );
     const rawSig = await stealthWallet.signMessage(arrayify(digest));


### PR DESCRIPTION
* Extracts common withdrawal functionality into shared internal methods
* Defines an interface for Umbra post withdraw hooks
* Implements withdraw methods that call this hook after the token withdrawal completes
* Adds tests exercising post withdraw hook usage

TODO:

- [x] Fix `umbra-js` signature methods (and others?)

closes #37 