### PR TITLE
Warn about bad privacy

### DIFF
--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -243,7 +243,7 @@ function useReceivedFundsTable(announcements: UserAnnouncement[]) {
    * @param announcement Announcement to withdraw
    */
   async function initializeWithdraw(announcement: UserAnnouncement) {
-    // Check if withdrawal destination is safea
+    // Check if withdrawal destination is safe
     activeAnnouncement.value = announcement;
     const { safe, reason } = await isAddressSafe(
       destinationAddress.value,

--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -1,5 +1,14 @@
 <template>
   <div>
+    <!-- Modal to show when warning user of bad privacy hygiene -->
+    <q-dialog v-model="showPrivacyModal">
+      <account-receive-table-warning
+        @acknowledged="showPrivacyModal = false"
+        :addressDescription="privacyModalAddressDescription"
+        class="q-pa-lg"
+      />
+    </q-dialog>
+
     <div v-if="isLoading" class="text-center">
       <loading-spinner />
       <div class="text-center text-italic">Scanning for funds...</div>
@@ -126,8 +135,10 @@ import { Web3ProviderBaseInterface } from '@opengsn/gsn/dist/src/common/types/Al
 import useWalletStore from 'src/store/wallet';
 import useAlerts from 'src/utils/alerts';
 import UmbraRelayRecipient from 'src/contracts/umbra-relay-recipient.json';
+import AccountReceiveTableWarning from 'components/AccountReceiveTableWarning.vue';
 import { SupportedChainIds } from 'components/models';
 import { lookupOrFormatAddresses, toAddress } from 'src/utils/address';
+import BaseButton from './BaseButton.vue';
 
 function useReceivedFundsTable(announcements: UserAnnouncement[]) {
   const { tokens, signer, provider, umbra, spendingKeyPair, domainService } = useWalletStore();
@@ -135,6 +146,8 @@ function useReceivedFundsTable(announcements: UserAnnouncement[]) {
   const paginationConfig = { rowsPerPage: 25 };
   const expanded = ref<string[]>([]); // for managing expansion rows
   const isLoading = ref(false);
+  const showPrivacyModal = ref(false);
+  const privacyModalAddressDescription = ref('a wallet that may be publicly associated with you');
   const destinationAddress = ref('');
   const isWithdrawInProgress = ref(false);
   const mainTableColumns = [
@@ -310,6 +323,8 @@ function useReceivedFundsTable(announcements: UserAnnouncement[]) {
   return {
     isWithdrawInProgress,
     isLoading,
+    showPrivacyModal,
+    privacyModalAddressDescription,
     expanded,
     copySenderAddress,
     openInEtherscan,
@@ -328,6 +343,7 @@ function useReceivedFundsTable(announcements: UserAnnouncement[]) {
 
 export default defineComponent({
   name: 'AccountReceiveTable',
+  components: { AccountReceiveTableWarning, BaseButton },
   props: {
     announcements: {
       type: (undefined as unknown) as PropType<UserAnnouncement[]>,

--- a/frontend/src/components/AccountReceiveTableWarning.vue
+++ b/frontend/src/components/AccountReceiveTableWarning.vue
@@ -8,12 +8,15 @@
 
     <q-card-section>
       You are withdrawing to {{ addressDescription }}. <span class="text-bold">This is not recommended</span> unless you
-      know what you are doing, as this may reduce or entirely remove the privacy guarantees provided by Umbra.
+      know what you are doing, as this may reduce or entirely remove the privacy properties provided by Umbra.
     </q-card-section>
 
     <q-card-section>
       <div class="row justify-evenly">
-        <base-button label="Learn More" :outline="true" :to="{ name: 'FAQ' }" />
+        <router-link class="no-text-decoration" target="_blank" :to="{ name: 'FAQ' }">
+          <!-- Button does nothing on click, but we wrap with router-link to open the page in a new tab -->
+          <base-button label="Learn More" :outline="true" />
+        </router-link>
         <base-button label="I acknowledge the risks" @click="context.emit('acknowledged')" />
       </div>
     </q-card-section>

--- a/frontend/src/components/AccountReceiveTableWarning.vue
+++ b/frontend/src/components/AccountReceiveTableWarning.vue
@@ -7,9 +7,8 @@
     </q-card-section>
 
     <q-card-section>
-      It looks like you are withdrawing to {{ addressDescription }}.
-      <span class="text-bold">This is not recommended</span> unless you know what you are doing, as this may reduce or
-      entirely remove the privacy guarantees provided by Umbra.
+      You are withdrawing to {{ addressDescription }}. <span class="text-bold">This is not recommended</span> unless you
+      know what you are doing, as this may reduce or entirely remove the privacy guarantees provided by Umbra.
     </q-card-section>
 
     <q-card-section>

--- a/frontend/src/components/AccountReceiveTableWarning.vue
+++ b/frontend/src/components/AccountReceiveTableWarning.vue
@@ -1,0 +1,41 @@
+<template>
+  <q-card class="border-top-thick">
+    <q-card-section>
+      <h5 class="text-bold text-center q-mt-none">
+        <q-icon name="fas fa-exclamation-triangle" color="warning" left />Warning!
+      </h5>
+    </q-card-section>
+
+    <q-card-section>
+      It looks like you are withdrawing to {{ addressDescription }}.
+      <span class="text-bold">This is not recommended</span> unless you know what you are doing, as this may reduce or
+      entirely remove the privacy guarantees provided by Umbra.
+    </q-card-section>
+
+    <q-card-section>
+      <div class="row justify-evenly">
+        <base-button label="Learn More" :outline="true" :to="{ name: 'FAQ' }" />
+        <base-button label="I acknowledge the risks" @click="context.emit('acknowledged')" />
+      </div>
+    </q-card-section>
+  </q-card>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api';
+
+export default defineComponent({
+  name: 'AccountReceiveTableWarning',
+
+  props: {
+    addressDescription: {
+      type: String,
+      required: true,
+    },
+  },
+
+  setup(_props, context) {
+    return { context };
+  },
+});
+</script>

--- a/frontend/src/components/BaseButton.vue
+++ b/frontend/src/components/BaseButton.vue
@@ -14,6 +14,7 @@
       :outline="outline"
       :padding="padding"
       :text-color="textColor"
+      :to="to"
       :type="type"
       @click="handleClick"
     >
@@ -89,6 +90,12 @@ export default defineComponent({
 
     textColor: {
       type: String,
+      required: false,
+      default: undefined,
+    },
+
+    to: {
+      type: Object,
       required: false,
       default: undefined,
     },

--- a/frontend/src/components/BaseButton.vue
+++ b/frontend/src/components/BaseButton.vue
@@ -14,7 +14,6 @@
       :outline="outline"
       :padding="padding"
       :text-color="textColor"
-      :to="to"
       :type="type"
       @click="handleClick"
     >
@@ -90,12 +89,6 @@ export default defineComponent({
 
     textColor: {
       type: String,
-      required: false,
-      default: undefined,
-    },
-
-    to: {
-      type: Object,
       required: false,
       default: undefined,
     },

--- a/frontend/src/css/app.sass
+++ b/frontend/src/css/app.sass
@@ -141,3 +141,6 @@ p, div
 
 .d-inline-block
   display: inline-block
+
+.border-top-thick
+  border-top: 5px solid $primary

--- a/frontend/src/css/app.sass
+++ b/frontend/src/css/app.sass
@@ -87,7 +87,7 @@ p, div
   text-align: center
 
 .form
-  max-width: 500px
+  max-width: 510px
   margin: 0 auto
 
 .horizontal-center

--- a/frontend/src/utils/address.ts
+++ b/frontend/src/utils/address.ts
@@ -100,22 +100,22 @@ export const isAddressSafe = async (name: string, userAddress: string, domainSer
   if (cns.isCnsDomain(name)) return { safe: false, reason: `${name}, which is a publicly viewable CNS name` };
 
   // We aren't withdrawing to a domain, so let's get the checksummed address.
-  const address = getAddress(name);
+  const destinationAddress = getAddress(name);
   const provider = domainService.provider as Provider;
 
   // Check if address resolves to an ENS name
-  const ensName = await lookupEnsName(address, provider);
+  const ensName = await lookupEnsName(destinationAddress, provider);
   if (ensName) return { safe: false, reason: `an address that resolves to the publicly viewable ENS name ${ensName}` };
 
   // Check if address owns a CNS name
-  const cnsName = await lookupCnsName(address, provider);
+  const cnsName = await lookupCnsName(destinationAddress, provider);
   if (cnsName) return { safe: false, reason: `an address that resolves to the publicly viewable CNS name ${cnsName}` };
 
   // Check if address is the wallet user is logged in with
-  if (address === userAddress) return { safe: false, reason: 'the same address as the connected wallet' };
+  if (destinationAddress === userAddress) return { safe: false, reason: 'the same address as the connected wallet' };
 
   // Check if address owns any POAPs
-  if (await hasPOAPs(userAddress)) return { safe: false, reason: 'an address that has POAP tokens' };
+  if (await hasPOAPs(destinationAddress)) return { safe: false, reason: 'an address that has POAP tokens' };
 
   // Check if address has contributed to Gitcoin Grants
   // TODO


### PR DESCRIPTION
Closes #107

For now, we show a modal that gives two options: Learn More, or Acknowledge the Risks. The latter continues with withdrawal, and the former links to the FAQ page. Once we update the FAQ / write more docs, we can change where that links to if we want

- [x]  Withdrawal to the address they're logged in yet
- [x]  Withdrawal to ENS/CNS name
- [x]  Withdrawal to address that reverse resolves via ENS
- [x]  Withdrawal to address that owns CNS names
- [ ] Withdrawal to address that owns ENS names: They have a subgraph, but not sure how to write the proper query—create issue to implement this later
- [x]  Withdrawal to address that owns a POAP??
- [ ]  Withdrawal to address that has interacted with Gitcoin: There's an endpoint that returns all address that have donated to a grant, but it's a big file and CORS is not supported. Best option is probably to have a simple backend endpoint that stores all the addresses in a JSON file (which we'd update regularly). Then the endpoint returns true if the supplied address is in the file, false otherwise
