### PR TITLE
Advanced UI features

### DIFF
--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -87,6 +87,7 @@
               @click="expanded = expanded[0] === props.key ? [] : [props.key]"
               color="primary"
               :dense="true"
+              :disable="isWithdrawInProgress"
               :flat="true"
               :label="props.expand ? 'Hide' : 'Withdraw'"
             />

--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -72,6 +72,9 @@
                   <span>{{ col.value.from }}</span>
                   <q-icon class="copy-icon" name="far fa-copy" right />
                 </div>
+                <div v-if="hasPayloadExtension(props.row.randomNumber)" class="text-caption text-grey">
+                  {{ formatPayloadExtensionText(props.row.randomNumber) }}
+                </div>
               </div>
 
               <!-- Default -->
@@ -158,7 +161,9 @@ import { computed, defineComponent, onMounted, PropType, ref } from '@vue/compos
 import { date, copyToClipboard } from 'quasar';
 import { Contract } from 'ethers';
 import { BigNumber } from '@ethersproject/bignumber';
+import { arrayify } from '@ethersproject/bytes';
 import { Block, ExternalProvider, TransactionResponse, Web3Provider } from '@ethersproject/providers';
+import { toUtf8String } from '@ethersproject/strings';
 import { formatUnits } from '@ethersproject/units';
 import { DomainService, Umbra, UserAnnouncement, KeyPair } from '@umbra/umbra-js';
 import { RelayProvider } from '@opengsn/gsn/dist/src/relayclient/RelayProvider';
@@ -235,6 +240,9 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
   // Table formatters and helpers
   const formatDate = (timestamp: number) => date.formatDate(timestamp, 'YYYY-MM-DD');
   const formatTime = (timestamp: number) => date.formatDate(timestamp, 'H:mm A');
+  const zeroPrefix = '0x00000000000000000000000000000000'; // 16 bytes of zeros
+  const hasPayloadExtension = (randomNumber: string) => randomNumber.slice(0, 34) !== zeroPrefix;
+  const formatPayloadExtensionText = (randomNumber: string) => toUtf8String(arrayify(randomNumber.slice(0, 34)));
   const isEth = (tokenAddress: string) => tokenAddress === '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
   const getTokenInfo = (tokenAddress: string) => tokens.value.filter((token) => token.address === tokenAddress)[0];
   const getStealthBalance = async (tokenAddress: string, userAddress: string) => {
@@ -407,10 +415,12 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
     expanded,
     formatAmount,
     formatDate,
+    formatPayloadExtensionText,
     formattedAnnouncements,
     formatTime,
     getTokenLogoUri,
     getTokenSymbol,
+    hasPayloadExtension,
     initializeWithdraw,
     isLoading,
     isWithdrawInProgress,

--- a/frontend/src/components/BaseInput.vue
+++ b/frontend/src/components/BaseInput.vue
@@ -175,6 +175,7 @@ export default Vue.extend({
 
     hideHint() {
       this.hintString = '';
+      this.$emit('blur', this.content);
     },
 
     showHint() {

--- a/frontend/src/components/BaseInput.vue
+++ b/frontend/src/components/BaseInput.vue
@@ -32,6 +32,17 @@
         @click="handleClick"
       />
     </template>
+    <template v-else-if="counter" v-slot:append>
+      <q-circular-progress
+        :value="counter"
+        size="2.75rem"
+        :color="counter > 100 ? 'negative' : 'primary'"
+        show-value
+        track-color="grey-4"
+      >
+        {{ counter }} %
+      </q-circular-progress>
+    </template>
   </q-input>
 </template>
 
@@ -74,6 +85,12 @@ export default Vue.extend({
 
     bgColor: {
       type: String,
+      required: false,
+      default: undefined,
+    },
+
+    counter: {
+      type: Number,
       required: false,
       default: undefined,
     },

--- a/frontend/src/css/app.sass
+++ b/frontend/src/css/app.sass
@@ -87,7 +87,12 @@ p, div
   text-align: center
 
 .form
-  max-width: 510px
+  max-width: 475px
+  margin: 0 auto
+
+.form-wide
+  // Slightly wider form to ensure withdrawal addresses and private keys don't wrap on the receive table
+  max-width: 525px
   margin: 0 auto
 
 .horizontal-center

--- a/frontend/src/layouts/BaseLayout.vue
+++ b/frontend/src/layouts/BaseLayout.vue
@@ -130,21 +130,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref, watchEffect } from '@vue/composition-api';
-import { Dark, LocalStorage } from 'quasar';
+import { defineComponent, ref, watchEffect } from '@vue/composition-api';
 import useSettingsStore from 'src/store/settings';
 import useWalletStore from 'src/store/wallet';
-
-function useDarkMode() {
-  onMounted(() => Dark.set(Boolean(LocalStorage.getItem('is-dark'))));
-
-  function toggleDarkMode() {
-    Dark.set(!Dark.isActive);
-    LocalStorage.set('is-dark', Dark.isActive);
-  }
-
-  return { toggleDarkMode };
-}
 
 function useWallet() {
   const { userDisplayName, network } = useWalletStore();
@@ -162,8 +150,8 @@ function useWallet() {
 export default defineComponent({
   name: 'BaseLayout',
   setup() {
-    const { advancedMode, toggleAdvancedMode } = useSettingsStore();
-    return { advancedMode, toggleAdvancedMode, ...useDarkMode(), ...useWallet() };
+    const { advancedMode, toggleAdvancedMode, isDark, toggleDarkMode } = useSettingsStore();
+    return { advancedMode, toggleAdvancedMode, isDark, toggleDarkMode, ...useWallet() };
   },
 });
 </script>

--- a/frontend/src/layouts/BaseLayout.vue
+++ b/frontend/src/layouts/BaseLayout.vue
@@ -52,8 +52,13 @@
 
             <!-- ADDRESS AND SETTINGS AND SETTINGS -->
             <div class="col-auto q-mr-md">
-              <div v-if="userDisplayName" class="text-caption dark-toggle">
-                {{ userDisplayName }}
+              <div>
+                <span v-if="userDisplayName" class="text-caption dark-toggle">
+                  {{ userDisplayName }}
+                </span>
+                <span v-if="advancedMode" class="q-ml-md">
+                  🧙 <q-tooltip content-class="bg-muted dark-toggle shadow-2 q-pa-md"> Advanced mode is on </q-tooltip>
+                </span>
               </div>
             </div>
           </div>
@@ -71,29 +76,44 @@
 
     <q-footer class="q-mx-md q-mb-md q-pt-xl" style="color: #000000; background-color: rgba(0, 0, 0, 0)">
       <div class="row justify-between">
-        <div class="col-auto">
+        <!-- Column 1: User settings -->
+        <div class="col">
+          <!-- Dark mode toggle -->
           <q-icon
             v-if="!$q.dark.isActive"
-            class="dark-toggle"
+            @click="toggleDarkMode"
+            class="dark-toggle cursor-pointer"
             name="fas fa-moon"
-            size="xs"
-            style="cursor: pointer"
-            @click="toggleDarkMode()"
           />
-          <q-icon
-            v-else
-            class="dark-toggle"
-            name="fas fa-sun"
-            size="xs"
-            style="cursor: pointer"
-            @click="toggleDarkMode()"
+          <q-icon v-else @click="toggleDarkMode" class="dark-toggle cursor-pointer" name="fas fa-sun" />
+
+          <!-- Advanced mode toggle -->
+          <q-toggle
+            @input="toggleAdvancedMode"
+            :value="advancedMode"
+            class="q-ml-lg"
+            color="primary"
+            icon="fas fa-cog"
           />
+          <span class="dark-toggle text-caption">Advanced mode {{ advancedMode ? 'on' : 'off' }}</span>
+          <span>
+            <q-icon class="dark-toggle" right name="fas fa-question-circle">
+              <q-tooltip content-class="bg-muted dark-toggle shadow-2 q-pa-md" max-width="14rem">
+                Enables advanced features such as private key export, additional recipient ID options, and event
+                scanning settings. <span class="text-bold">Use with caution!</span>
+              </q-tooltip>
+            </q-icon>
+          </span>
         </div>
-        <div class="col-auto text-caption">
+
+        <!-- Column 2: Built by ScopeLift -->
+        <div class="col text-center text-caption">
           Built by
           <a href="https://www.scopelift.co/" target="_blank" class="hyperlink">ScopeLift</a>
         </div>
-        <div class="col-auto">
+
+        <!-- Column 3: Links -->
+        <div class="col text-right">
           <a href="https://twitter.com/UmbraCash" target="_blank" class="no-text-decoration">
             <q-icon class="dark-toggle" name="fab fa-twitter" size="xs" />
           </a>
@@ -112,19 +132,18 @@
 <script lang="ts">
 import { defineComponent, onMounted, ref, watchEffect } from '@vue/composition-api';
 import { Dark, LocalStorage } from 'quasar';
+import useSettingsStore from 'src/store/settings';
 import useWalletStore from 'src/store/wallet';
 
 function useDarkMode() {
+  onMounted(() => Dark.set(Boolean(LocalStorage.getItem('is-dark'))));
+
   function toggleDarkMode() {
     Dark.set(!Dark.isActive);
     LocalStorage.set('is-dark', Dark.isActive);
   }
 
-  const mounted = onMounted(function () {
-    Dark.set(Boolean(LocalStorage.getItem('is-dark')));
-  });
-
-  return { toggleDarkMode, mounted };
+  return { toggleDarkMode };
 }
 
 function useWallet() {
@@ -143,7 +162,8 @@ function useWallet() {
 export default defineComponent({
   name: 'BaseLayout',
   setup() {
-    return { ...useDarkMode(), ...useWallet() };
+    const { advancedMode, toggleAdvancedMode } = useSettingsStore();
+    return { advancedMode, toggleAdvancedMode, ...useDarkMode(), ...useWallet() };
   },
 });
 </script>

--- a/frontend/src/pages/AccountReceive.vue
+++ b/frontend/src/pages/AccountReceive.vue
@@ -9,37 +9,47 @@
 
     <div v-else class="q-mx-auto" style="max-width: 800px">
       <!-- Waiting for signature -->
-      <div v-if="!hasKeys || scanStatus === 'waiting'" class="form">
-        <div v-if="!hasKeys" class="text-center q-mb-md">
+      <div v-if="needsSignature || scanStatus === 'waiting'" class="form">
+        <div v-if="needsSignature" class="text-center q-mb-md">
           This app needs your signature to scan for funds you've received
         </div>
         <div v-else class="text-center q-mb-md">Click below to scan for funds you've received</div>
-        <base-button @click="getPrivateKeysHandler" class="text-center" :label="hasKeys ? 'Scan' : 'Sign'" />
+        <base-button @click="getPrivateKeysHandler" class="text-center" :label="needsSignature ? 'Sign' : 'Scan'" />
 
         <!-- Advanced mode settings -->
-        <q-card v-if="advancedMode" class="card-border cursor-pointer q-pt-md q-px-md q-mt-xl">
+        <q-card v-if="advancedMode" class="q-pt-md q-px-md q-mt-xl">
           <q-card-section class="text-center text-primary text-h6 header-black q-pb-none">
             Scan Settings
           </q-card-section>
-          <q-card-section class="text-left">
-            <div>
-              Enter the start or end blocks to use when scanning for events. A blank start block will scan from block
-              zero, and a blank end block will scan through the current block.
-            </div>
-            <div class="row justify-between q-mt-lg">
-              <base-input
-                v-model.number="startBlockLocal"
-                @blur="setScanBlocks(startBlockLocal, endBlockLocal)"
-                class="col-5"
-                label="Start block"
-              />
-              <base-input
-                v-model.number="endBlockLocal"
-                @blur="setScanBlocks(startBlockLocal, endBlockLocal)"
-                class="col-5"
-                label="End block"
-              />
-            </div>
+          <q-card-section>
+            <q-form class="text-left" ref="settingsFormRef">
+              <div>
+                Enter the start or end blocks to use when scanning for events. A blank start block will scan from block
+                zero, and a blank end block will scan through the current block.
+              </div>
+              <div class="row justify-start">
+                <base-input
+                  v-model.number="startBlockLocal"
+                  @blur="setScanBlocks(startBlockLocal, endBlockLocal)"
+                  class="col-5"
+                  label="Start block"
+                  :rules="isValidStartBlock"
+                />
+                <base-input
+                  v-model.number="endBlockLocal"
+                  @blur="setScanBlocks(startBlockLocal, endBlockLocal)"
+                  class="col-5 q-ml-md"
+                  label="End block"
+                  :rules="isValidEndBlock"
+                />
+              </div>
+              <div>
+                Enter the private key to use when scanning for events. A blank private key will use the ones generated
+                from your signature.
+              </div>
+              <!-- Unlike start blocks, no action on blur because we don't want to save private key to LocalStorage -->
+              <base-input v-model="scanPrivateKeyLocal" label="Private key" :rules="isValidPrivateKey" />
+            </q-form>
           </q-card-section>
         </q-card>
       </div>
@@ -52,15 +62,17 @@
 
       <!-- Scanning complete -->
       <div v-else-if="scanStatus === 'complete'" class="text-center">
-        <account-receive-table :announcements="userAnnouncements" @reset="scanStatus = 'waiting'" />
+        <account-receive-table :announcements="userAnnouncements" @reset="setFormStatus('waiting', '')" />
       </div>
     </div>
   </q-page>
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, ref } from '@vue/composition-api';
+import { computed, defineComponent, onMounted, ref } from '@vue/composition-api';
+import { QForm } from 'quasar';
 import { UserAnnouncement } from '@umbra/umbra-js';
+import { isHexString } from '@ethersproject/bytes';
 import useSettingsStore from 'src/store/settings';
 import useWallet from 'src/store/wallet';
 import AccountReceiveTable from 'components/AccountReceiveTable.vue';
@@ -68,53 +80,90 @@ import ConnectWalletCard from 'components/ConnectWalletCard.vue';
 
 function useScan() {
   const { getPrivateKeys, umbra, spendingKeyPair, viewingKeyPair, hasKeys, userAddress } = useWallet();
-  const scanStatus = ref<'waiting' | 'scanning' | 'complete'>('waiting');
+  type ScanStatus = 'waiting' | 'scanning' | 'complete';
+  const scanStatus = ref<ScanStatus>('waiting');
   const userAnnouncements = ref<UserAnnouncement[]>([]);
 
   // Start and end blocks for advanced mode settings
-  const { advancedMode, startBlock, endBlock, setScanBlocks } = useSettingsStore();
+  const { advancedMode, startBlock, endBlock, setScanBlocks, setScanPrivateKey } = useSettingsStore();
   const startBlockLocal = ref<number>();
   const endBlockLocal = ref<number>();
+  const scanPrivateKeyLocal = ref<string>();
+  const needsSignature = computed(() => !hasKeys.value && !scanPrivateKeyLocal.value);
+  const settingsFormRef = ref<QForm>(); // for programtically verifying settings form
+
+  // Form validators and configurations
+  const invalidPrivateKeyMsg = 'Please enter a valid private key starting with 0x';
+  const isValidPrivateKey = (val: string) => !val || (isHexString(val) && val.length === 66) || invalidPrivateKeyMsg;
+  const isValidStartBlock = (val: string) => !val || Number(val) > 0 || 'Please enter a valid start block';
+  const isValidEndBlock = (val: string) => !val || Number(val) > 0 || 'Please enter a valid start block';
+  const setFormStatus = (scanStatusVal: ScanStatus, scanPrivateKey: string) => {
+    scanStatus.value = scanStatusVal;
+    setScanPrivateKey(scanPrivateKey);
+    scanPrivateKeyLocal.value = scanPrivateKey;
+  };
 
   onMounted(async () => {
-    // Read in the scan range
-    startBlockLocal.value = startBlock.value;
-    endBlockLocal.value = endBlock.value;
-
-    // If user already signed and we have their keys in memory, start scanning
-    if (hasKeys.value) await scan();
+    startBlockLocal.value = startBlock.value; // read in last used startBlock
+    endBlockLocal.value = endBlock.value; // read in last used endBlock
+    if (hasKeys.value) await scan(); // if user already signed and we have their keys in memory, start scanning
   });
 
   async function getPrivateKeysHandler() {
-    if (startBlock.value && endBlock.value && Number(startBlock.value) > Number(endBlock.value)) {
-      throw new Error('Invalid start or end block values');
+    // Validate form
+    if (advancedMode.value) {
+      const isFormValid = await settingsFormRef.value?.validate(true);
+      if (!isFormValid) return;
     }
-    const success = await getPrivateKeys();
-    if (!success) return; // user denied signature or an error was thrown
-    await scan(); // start scanning right after we get the user's signature
+    if (Number(startBlock.value) > Number(endBlock.value)) {
+      throw new Error('End block is larger than start block');
+    }
+
+    // Get user's signature if required
+    if (needsSignature.value) {
+      const success = await getPrivateKeys();
+      if (!success) return; // user denied signature or an error was thrown
+    }
+
+    // Save off the scanPrivateKeyLocal to memory if it exists, then scan
+    if (scanPrivateKeyLocal.value) setScanPrivateKey(scanPrivateKeyLocal.value);
+    await scan();
   }
 
   async function scan() {
     if (!umbra.value) throw new Error('No umbra instance found. Please make sure you are on a supported network');
     scanStatus.value = 'scanning';
-    const { userAnnouncements: announcements } = await umbra.value.scan(
-      String(spendingKeyPair.value?.publicKeyHex),
-      String(viewingKeyPair.value?.privateKeyHex),
-      { startBlock: startBlock.value, endBlock: endBlock.value } // overrides
-    );
+
+    // Check for manually entered private key in advancedMode, otherwise use the key from user's signature
+    const chooseKey = (keyPair: string | undefined | null) => {
+      if (advancedMode.value && scanPrivateKeyLocal.value) return String(scanPrivateKeyLocal.value);
+      return String(keyPair);
+    };
+
+    // Scan for funds
+    const spendingPubKey = chooseKey(spendingKeyPair.value?.publicKeyHex);
+    const viewingPrivKey = chooseKey(viewingKeyPair.value?.privateKeyHex);
+    const overrides = { startBlock: startBlock.value, endBlock: endBlock.value };
+    const { userAnnouncements: announcements } = await umbra.value.scan(spendingPubKey, viewingPrivKey, overrides);
     userAnnouncements.value = announcements;
     scanStatus.value = 'complete';
   }
 
   return {
-    userAddress,
-    hasKeys,
-    scanStatus,
-    startBlockLocal,
-    endBlockLocal,
     advancedMode,
-    setScanBlocks,
+    endBlockLocal,
     getPrivateKeysHandler,
+    isValidEndBlock,
+    isValidPrivateKey,
+    isValidStartBlock,
+    needsSignature,
+    scanPrivateKeyLocal,
+    scanStatus,
+    setFormStatus,
+    setScanBlocks,
+    settingsFormRef,
+    startBlockLocal,
+    userAddress,
     userAnnouncements,
   };
 }

--- a/frontend/src/pages/AccountReceive.vue
+++ b/frontend/src/pages/AccountReceive.vue
@@ -85,7 +85,7 @@ function useScan() {
   const userAnnouncements = ref<UserAnnouncement[]>([]);
 
   // Start and end blocks for advanced mode settings
-  const { advancedMode, startBlock, endBlock, setScanBlocks, setScanPrivateKey } = useSettingsStore();
+  const { advancedMode, startBlock, endBlock, setScanBlocks, setScanPrivateKey, scanPrivateKey } = useSettingsStore();
   const startBlockLocal = ref<number>();
   const endBlockLocal = ref<number>();
   const scanPrivateKeyLocal = ref<string>();
@@ -93,12 +93,14 @@ function useScan() {
   const settingsFormRef = ref<QForm>(); // for programtically verifying settings form
 
   // Form validators and configurations
-  const invalidPrivateKeyMsg = 'Please enter a valid private key starting with 0x';
-  const isValidPrivateKey = (val: string) => !val || (isHexString(val) && val.length === 66) || invalidPrivateKeyMsg;
+  const badPrivKeyMsg = 'Please enter a valid private key';
+  const isAnyHex = (val: string) => isHexString(val) || isHexString(`0x${val}`);
+  const isValidPrivateKey = (val: string) => !val || (isAnyHex(val) && [66, 64].includes(val.length)) || badPrivKeyMsg;
   const isValidStartBlock = (val: string) => !val || Number(val) > 0 || 'Please enter a valid start block';
   const isValidEndBlock = (val: string) => !val || Number(val) > 0 || 'Please enter a valid start block';
   const setFormStatus = (scanStatusVal: ScanStatus, scanPrivateKey: string) => {
     scanStatus.value = scanStatusVal;
+    if (scanPrivateKey.length === 64) scanPrivateKey = `0x${scanPrivateKey}`;
     setScanPrivateKey(scanPrivateKey);
     scanPrivateKeyLocal.value = scanPrivateKey;
   };
@@ -136,7 +138,7 @@ function useScan() {
 
     // Check for manually entered private key in advancedMode, otherwise use the key from user's signature
     const chooseKey = (keyPair: string | undefined | null) => {
-      if (advancedMode.value && scanPrivateKeyLocal.value) return String(scanPrivateKeyLocal.value);
+      if (advancedMode.value && scanPrivateKey.value) return String(scanPrivateKey.value);
       return String(keyPair);
     };
 

--- a/frontend/src/pages/AccountReceive.vue
+++ b/frontend/src/pages/AccountReceive.vue
@@ -9,9 +9,39 @@
 
     <div v-else class="q-mx-auto" style="max-width: 800px">
       <!-- Waiting for signature -->
-      <div v-if="!hasKeys" class="form">
-        <div class="text-center q-mb-md">This app needs your signature to scan for funds you've received</div>
-        <base-button @click="getPrivateKeysHandler" class="text-center" label="Sign" />
+      <div v-if="!hasKeys || scanStatus === 'waiting'" class="form">
+        <div v-if="!hasKeys" class="text-center q-mb-md">
+          This app needs your signature to scan for funds you've received
+        </div>
+        <div v-else class="text-center q-mb-md">Click below to scan for funds you've received</div>
+        <base-button @click="getPrivateKeysHandler" class="text-center" :label="hasKeys ? 'Scan' : 'Sign'" />
+
+        <!-- Advanced mode settings -->
+        <q-card v-if="advancedMode" class="card-border cursor-pointer q-pt-md q-px-md q-mt-xl">
+          <q-card-section class="text-center text-primary text-h6 header-black q-pb-none">
+            Scan Settings
+          </q-card-section>
+          <q-card-section class="text-left">
+            <div>
+              Enter the start or end blocks to use when scanning for events. A blank start block will scan from block
+              zero, and a blank end block will scan through the current block.
+            </div>
+            <div class="row justify-between q-mt-lg">
+              <base-input
+                v-model.number="startBlockLocal"
+                @blur="setScanBlocks(startBlockLocal, endBlockLocal)"
+                class="col-5"
+                label="Start block"
+              />
+              <base-input
+                v-model.number="endBlockLocal"
+                @blur="setScanBlocks(startBlockLocal, endBlockLocal)"
+                class="col-5"
+                label="End block"
+              />
+            </div>
+          </q-card-section>
+        </q-card>
       </div>
 
       <!-- Scanning in progress -->
@@ -22,7 +52,7 @@
 
       <!-- Scanning complete -->
       <div v-else-if="scanStatus === 'complete'" class="text-center">
-        <account-receive-table :announcements="userAnnouncements" />
+        <account-receive-table :announcements="userAnnouncements" @reset="scanStatus = 'waiting'" />
       </div>
     </div>
   </q-page>
@@ -31,6 +61,7 @@
 <script lang="ts">
 import { defineComponent, onMounted, ref } from '@vue/composition-api';
 import { UserAnnouncement } from '@umbra/umbra-js';
+import useSettingsStore from 'src/store/settings';
 import useWallet from 'src/store/wallet';
 import AccountReceiveTable from 'components/AccountReceiveTable.vue';
 import ConnectWalletCard from 'components/ConnectWalletCard.vue';
@@ -40,33 +71,52 @@ function useScan() {
   const scanStatus = ref<'waiting' | 'scanning' | 'complete'>('waiting');
   const userAnnouncements = ref<UserAnnouncement[]>([]);
 
+  // Start and end blocks for advanced mode settings
+  const { advancedMode, startBlock, endBlock, setScanBlocks } = useSettingsStore();
+  const startBlockLocal = ref<number>();
+  const endBlockLocal = ref<number>();
+
   onMounted(async () => {
+    // Read in the scan range
+    startBlockLocal.value = startBlock.value;
+    endBlockLocal.value = endBlock.value;
+
     // If user already signed and we have their keys in memory, start scanning
-    if (hasKeys.value) {
-      await scan();
-    }
+    if (hasKeys.value) await scan();
   });
 
   async function getPrivateKeysHandler() {
+    if (startBlock.value && endBlock.value && Number(startBlock.value) > Number(endBlock.value)) {
+      throw new Error('Invalid start or end block values');
+    }
     const success = await getPrivateKeys();
     if (!success) return; // user denied signature or an error was thrown
     await scan(); // start scanning right after we get the user's signature
   }
 
   async function scan() {
-    if (!umbra.value) {
-      throw new Error('No umbra instance found. Please make sure you are on a supported network');
-    }
+    if (!umbra.value) throw new Error('No umbra instance found. Please make sure you are on a supported network');
     scanStatus.value = 'scanning';
     const { userAnnouncements: announcements } = await umbra.value.scan(
       String(spendingKeyPair.value?.publicKeyHex),
-      String(viewingKeyPair.value?.privateKeyHex)
+      String(viewingKeyPair.value?.privateKeyHex),
+      { startBlock: startBlock.value, endBlock: endBlock.value } // overrides
     );
     userAnnouncements.value = announcements;
     scanStatus.value = 'complete';
   }
 
-  return { userAddress, hasKeys, scanStatus, getPrivateKeysHandler, userAnnouncements };
+  return {
+    userAddress,
+    hasKeys,
+    scanStatus,
+    startBlockLocal,
+    endBlockLocal,
+    advancedMode,
+    setScanBlocks,
+    getPrivateKeysHandler,
+    userAnnouncements,
+  };
 }
 
 export default defineComponent({

--- a/frontend/src/pages/AccountSend.vue
+++ b/frontend/src/pages/AccountSend.vue
@@ -31,7 +31,14 @@
 
       <!-- Memo (payload extension) -->
       <div>Include a brief, optional<span v-if="advancedMode"> 16 byte</span> memo</div>
-      <base-input v-model="memo" :disable="isSending" placeholder="Memo" lazy-rules :rules="isValidMemo" />
+      <base-input
+        v-model="memo"
+        :counter="payloadCounter"
+        :disable="isSending"
+        placeholder="Memo"
+        lazy-rules
+        :rules="isValidMemo"
+      />
 
       <!-- Send button -->
       <div>
@@ -74,6 +81,10 @@ function useSendForm() {
   const humanAmount = ref<string>();
   const memo = ref<string>();
   const payloadExtension = computed(() => (memo.value ? hexlify(toUtf8Bytes(memo.value)) : zeroPrefix));
+  const payloadCounter = computed(() =>
+    // Counts percentage progress of payload extension. Reaches 100% at 16 bytes
+    payloadExtension.value === zeroPrefix ? 0 : Math.round((100 * payloadExtension.value.slice(2).length) / 32)
+  );
 
   function isValidId(val: string) {
     if (val && (ens.isEnsDomain(val) || cns.isCnsDomain(val))) return true;
@@ -160,10 +171,11 @@ function useSendForm() {
     humanAmount,
     isSending,
     isValidId,
-    isValidTokenAmount,
     isValidMemo,
+    isValidTokenAmount,
     memo,
     onFormSubmit,
+    payloadCounter,
     recipientId,
     sendFormRef,
     token,

--- a/frontend/src/store/settings.ts
+++ b/frontend/src/store/settings.ts
@@ -50,6 +50,7 @@ export default function useSettingsStore() {
   }
 
   function setScanPrivateKey(key: string) {
+    if (key.length === 64) key = `0x${key}`;
     scanPrivateKey.value = key; // we save this in memory for access by components, but do not save it to LocalStorage
   }
 

--- a/frontend/src/store/settings.ts
+++ b/frontend/src/store/settings.ts
@@ -12,12 +12,16 @@ const settings = {
 // Shared state between instances
 const isDark = ref(false); // true if user has dark mode turned on
 const advancedMode = ref(false); // true if user has advanced mode turned on
+const startBlock = ref<number | undefined>(undefined); // block number to start scanning from
+const endBlock = ref<number | undefined>(undefined); // block number to scan through
 
 // Composition function for managing state
 export default function useSettingsStore() {
   onMounted(() => {
-    setDarkMode(Boolean(LocalStorage.getItem('is-dark')));
+    setDarkMode(Boolean(LocalStorage.getItem(settings.isDark)));
     advancedMode.value = Boolean(LocalStorage.getItem(settings.advancedMode));
+    startBlock.value = Number(LocalStorage.getItem(settings.startBlock)) || undefined;
+    endBlock.value = Number(LocalStorage.getItem(settings.endBlock)) || undefined;
   });
 
   function setDarkMode(status: boolean) {
@@ -37,10 +41,20 @@ export default function useSettingsStore() {
     LocalStorage.set(settings.advancedMode, advancedMode.value);
   }
 
+  function setScanBlocks(startBlock_: number, endBlock_: number) {
+    startBlock.value = startBlock_;
+    endBlock.value = endBlock_;
+    LocalStorage.set(settings.startBlock, startBlock_);
+    LocalStorage.set(settings.endBlock, endBlock_);
+  }
+
   return {
     toggleDarkMode,
     toggleAdvancedMode,
+    setScanBlocks,
     isDark: computed(() => isDark.value),
     advancedMode: computed(() => advancedMode.value),
+    startBlock: computed(() => startBlock.value),
+    endBlock: computed(() => endBlock.value),
   };
 }

--- a/frontend/src/store/settings.ts
+++ b/frontend/src/store/settings.ts
@@ -1,17 +1,46 @@
 import { computed, onMounted, ref } from '@vue/composition-api';
-import { LocalStorage } from 'quasar';
+import { Dark, LocalStorage } from 'quasar';
+
+// Local storage key names
+const settings = {
+  isDark: 'is-dark',
+  advancedMode: 'advanced-mode',
+  startBlock: 'start-block',
+  endBlock: 'end-block',
+};
 
 // Shared state between instances
+const isDark = ref(false); // true if user has dark mode turned on
 const advancedMode = ref(false); // true if user has advanced mode turned on
 
 // Composition function for managing state
 export default function useSettingsStore() {
-  onMounted(() => (advancedMode.value = Boolean(LocalStorage.getItem('advanced-mode'))));
+  onMounted(() => {
+    setDarkMode(Boolean(LocalStorage.getItem('is-dark')));
+    advancedMode.value = Boolean(LocalStorage.getItem(settings.advancedMode));
+  });
+
+  function setDarkMode(status: boolean) {
+    // In addition to Quasars `Dark` param, we use the isDark state value with this setter, so we can reactively track
+    // the dark mode status in Vue
+    isDark.value = status;
+    Dark.set(status);
+  }
+
+  function toggleDarkMode() {
+    setDarkMode(!isDark.value);
+    LocalStorage.set(settings.isDark, isDark.value);
+  }
 
   function toggleAdvancedMode() {
     advancedMode.value = !advancedMode.value;
-    LocalStorage.set('advanced-mode', advancedMode.value);
+    LocalStorage.set(settings.advancedMode, advancedMode.value);
   }
 
-  return { toggleAdvancedMode, advancedMode: computed(() => advancedMode.value) };
+  return {
+    toggleDarkMode,
+    toggleAdvancedMode,
+    isDark: computed(() => isDark.value),
+    advancedMode: computed(() => advancedMode.value),
+  };
 }

--- a/frontend/src/store/settings.ts
+++ b/frontend/src/store/settings.ts
@@ -14,6 +14,7 @@ const isDark = ref(false); // true if user has dark mode turned on
 const advancedMode = ref(false); // true if user has advanced mode turned on
 const startBlock = ref<number | undefined>(undefined); // block number to start scanning from
 const endBlock = ref<number | undefined>(undefined); // block number to scan through
+const scanPrivateKey = ref<string>(); // private key entered when scanning
 
 // Composition function for managing state
 export default function useSettingsStore() {
@@ -48,13 +49,19 @@ export default function useSettingsStore() {
     LocalStorage.set(settings.endBlock, endBlock_);
   }
 
+  function setScanPrivateKey(key: string) {
+    scanPrivateKey.value = key; // we save this in memory for access by components, but do not save it to LocalStorage
+  }
+
   return {
     toggleDarkMode,
     toggleAdvancedMode,
     setScanBlocks,
+    setScanPrivateKey,
     isDark: computed(() => isDark.value),
     advancedMode: computed(() => advancedMode.value),
     startBlock: computed(() => startBlock.value),
     endBlock: computed(() => endBlock.value),
+    scanPrivateKey: computed(() => scanPrivateKey.value),
   };
 }

--- a/frontend/src/store/settings.ts
+++ b/frontend/src/store/settings.ts
@@ -1,0 +1,17 @@
+import { computed, onMounted, ref } from '@vue/composition-api';
+import { LocalStorage } from 'quasar';
+
+// Shared state between instances
+const advancedMode = ref(false); // true if user has advanced mode turned on
+
+// Composition function for managing state
+export default function useSettingsStore() {
+  onMounted(() => (advancedMode.value = Boolean(LocalStorage.getItem('advanced-mode'))));
+
+  function toggleAdvancedMode() {
+    advancedMode.value = !advancedMode.value;
+    LocalStorage.set('advanced-mode', advancedMode.value);
+  }
+
+  return { toggleAdvancedMode, advancedMode: computed(() => advancedMode.value) };
+}

--- a/frontend/src/utils/address.ts
+++ b/frontend/src/utils/address.ts
@@ -34,19 +34,25 @@ export const lookupCnsName = async (address: string, provider: Provider) => {
   const url = chainId === 4 ? `${baseUrl}/dot-crypto-rinkeby-registry` : `${baseUrl}/dot-crypto-registry`;
 
   // Send request to get names
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      variables: { owner: address.toLowerCase() },
-      query: 'query domainsOfOwner($owner: String!) { domains(where: {owner: $owner}) { name } }',
-    }),
-  });
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        variables: { owner: address.toLowerCase() },
+        query: 'query domainsOfOwner($owner: String!) { domains(where: {owner: $owner}) { name } }',
+      }),
+    });
 
-  // Return the first name in the array, or undefined if user has no CNS names
-  const json = (await res.json()) as CnsQueryResponse;
-  const names = json.data.domains;
-  return names.length > 0 ? names[0].name : undefined;
+    // Return the first name in the array, or undefined if user has no CNS names
+    const json = (await res.json()) as CnsQueryResponse;
+    const names = json.data.domains;
+    return names.length > 0 ? names[0].name : undefined;
+  } catch (err) {
+    // Scenario that prompted this try/catch was that The Graph API threw with a CORS error on localhost, blocking login
+    console.error(err);
+    return undefined;
+  }
 };
 
 // Returns an ENS or CNS name if found, otherwise returns undefined

--- a/umbra-js/src/utils/utils.ts
+++ b/umbra-js/src/utils/utils.ts
@@ -9,7 +9,7 @@ import { resolveProperties } from '@ethersproject/properties';
 import { EtherscanProvider } from '@ethersproject/providers';
 import { recoverPublicKey } from '@ethersproject/signing-key';
 import { serialize as serializeTransaction } from '@ethersproject/transactions';
-import * as ens from './ens';
+import { ens, cns } from '..';
 import { DomainService } from '../classes/DomainService';
 import { EthersProvider, SignatureLike } from '../types';
 
@@ -120,20 +120,20 @@ async function getSentTransaction(address: string, ethersProvider: EthersProvide
  */
 export async function lookupRecipient(id: string, provider: EthersProvider) {
   // Check if identifier is a public key. If so we just return that directly
-  const isPublicKey = id.length === 132 && isHexString(id) && id.startsWith('0x04');
+  const isPublicKey = id.length === 132 && isHexString(id);
   if (isPublicKey) {
     return { spendingPublicKey: id, viewingPublicKey: id };
   }
 
   // Check if identifier is a transaction hash
-  const isTxHash = id.length === 66 && isHexString(id) && id.startsWith('0x');
+  const isTxHash = id.length === 66 && isHexString(id);
   if (isTxHash) {
     const publicKey = await recoverPublicKeyFromTransaction(id, provider);
     return { spendingPublicKey: publicKey, viewingPublicKey: publicKey };
   }
 
   // Check if this is a valid address
-  const isValidAddress = id.length === 42 && isHexString(id) && id.startsWith('0x');
+  const isValidAddress = id.length === 42 && isHexString(id);
   if (isValidAddress) {
     // Get last transaction hash sent by that address
     const txHash = await getSentTransaction(id, provider);
@@ -147,7 +147,7 @@ export async function lookupRecipient(id: string, provider: EthersProvider) {
   }
 
   // Check if this is a valid ENS or CNS name
-  const isDomainService = ens.isEnsDomain(id) || id.endsWith('.crypto');
+  const isDomainService = ens.isEnsDomain(id) || cns.isCnsDomain(id);
   if (isDomainService) {
     const domainService = new DomainService(provider);
     return domainService.getPublicKeys(id);


### PR DESCRIPTION
Closes #124, closes #106 (moves one task from #106 into #135 since I want to think of the cleanest way to do that and there's more pressing functionality first). Changes:

1. Export Private Key Of Receiving Stealth Address
2. Define start and end blocks for receive Announcement scanning
3. Send to a general ETH address using recovered TX pub key, transaction hash, or specific Public Key
4. Include a Payload Extension when sending
5. Display Payload Extension on receives (should this be there even in non-advanced mode?)

Notes: 
- The advanced toggle is in the footer
- Items 1, 2, and 3 are advanced-mode only feature. Items 4 and 5 are always present
- When advanced mode is on, the 🧙 emoji is shown in the top right with tooltip on hover. 
- Settings such as dark mode, start and end blocks, and advanced mode toggle are stored in local storage in a new Settings store (custom private key for scanning is intentionally not stored)