### PR TITLE
Remove elliptic

### DIFF
--- a/umbra-js/package.json
+++ b/umbra-js/package.json
@@ -25,7 +25,6 @@
     "bn.js": "^5.1.3",
     "buffer": "^6.0.2",
     "dotenv": "^8.2.0",
-    "eth-ens-namehash": "^2.0.8",
     "ethers": "^5.0.25",
     "noble-secp256k1": "^1.1.2"
   },

--- a/umbra-js/src/classes/RandomNumber.ts
+++ b/umbra-js/src/classes/RandomNumber.ts
@@ -6,7 +6,7 @@
 
 import { BigNumber } from '@ethersproject/bignumber';
 import { hexZeroPad, isHexString } from '@ethersproject/bytes';
-import { randomBytes } from '@ethersproject/random';
+import { utils } from 'noble-secp256k1';
 
 const zeroPrefix = '0x00000000000000000000000000000000'; // 16 bytes of zeros
 
@@ -21,7 +21,7 @@ export class RandomNumber {
    * hex string where the first two characters are 0x
    */
   constructor(readonly payloadExtension: string = zeroPrefix) {
-    // Validate it payload extension
+    // Validate payload extension
     if (!isHexString(payloadExtension)) {
       throw new Error('Payload extension is not a valid hex string');
     }
@@ -30,7 +30,7 @@ export class RandomNumber {
     }
 
     // Generate default random number without payload extension
-    const randomNumberAsBytes = randomBytes(this.randomLength);
+    const randomNumberAsBytes = utils.randomPrivateKey(this.randomLength);
     this.value = BigNumber.from(randomNumberAsBytes);
 
     // Payload extension is valid, so update the random number. If no payload extension is provided

--- a/umbra-js/src/types.ts
+++ b/umbra-js/src/types.ts
@@ -69,9 +69,3 @@ export interface UserAnnouncement {
   receipt: TransactionReceipt;
   isWithdrawn: boolean;
 }
-
-// ======================================= ENS-related types =======================================
-export type EnsNamehash = {
-  hash: (name: string) => string;
-  normalize: (name: string) => string;
-};

--- a/umbra-js/src/utils/ens.ts
+++ b/umbra-js/src/utils/ens.ts
@@ -2,13 +2,13 @@
  * @dev Functions for interacting with the Ethereum Name Service (ENS)
  */
 
-import { EthersProvider, EnsNamehash, TransactionResponse } from '../types';
+import { EthersProvider, TransactionResponse } from '../types';
 import { BigNumber } from '@ethersproject/bignumber';
 import { Zero } from '@ethersproject/constants';
+import { namehash as ensNamehash } from '@ethersproject/hash';
 import { KeyPair } from '../classes/KeyPair';
 import * as publicResolverAbi from '../abi/PublicResolver.json';
 import { createContract } from './utils';
-const ensNamehash: EnsNamehash = require('eth-ens-namehash'); // doesn't include TypeScript definitions
 
 type StealthKeys = {
   spendingPubKeyPrefix: BigNumber;
@@ -58,7 +58,7 @@ export function namehash(name: string) {
   if (!isEnsDomain(name)) {
     throw new Error(`Name does not end with supported suffix: ${supportedEnsDomains.join(', ')}`);
   }
-  return ensNamehash.hash(ensNamehash.normalize(name));
+  return ensNamehash(name);
 }
 
 /**


### PR DESCRIPTION
- Replaces `ethers.wallet.createRandom()` with noble-secp256k1's `randomPrivateKey()`, since `createRandom()` ultimately passes through elliptic at one point
- Removes the `eth-ens-namehash` package for getting the namehash of ENS names and we now use the ethers.js method instead