### PR TITLE
Umbrajs input validation + other cleanup

### DIFF
--- a/contracts/contracts/Umbra.sol
+++ b/contracts/contracts/Umbra.sol
@@ -29,7 +29,7 @@ contract Umbra is Ownable {
   // ======================================= State variables =======================================
 
   /// @dev Placeholder address used to identify transfer of native ETH
-  address public constant ETH_TOKEN_PLACHOLDER = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+  address internal constant ETH_TOKEN_PLACHOLDER = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
   /// @notice An ETH amount that must be sent alongside each payment; used as an anti-spam measure
   uint256 public toll;

--- a/contracts/contracts/Umbra.sol
+++ b/contracts/contracts/Umbra.sol
@@ -29,7 +29,7 @@ contract Umbra is Ownable {
   // ======================================= State variables =======================================
 
   /// @dev Placeholder address used to identify transfer of native ETH
-  address constant ETH_TOKEN_PLACHOLDER = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+  address public constant ETH_TOKEN_PLACHOLDER = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
   /// @notice An ETH amount that must be sent alongside each payment; used as an anti-spam measure
   uint256 public toll;

--- a/umbra-js/.eslintignore
+++ b/umbra-js/.eslintignore
@@ -4,3 +4,6 @@
 /test
 .eslintrc.js
 test-environment.config.js
+/coverage
+/docs
+hardhat.config.ts

--- a/umbra-js/.prettierignore
+++ b/umbra-js/.prettierignore
@@ -2,4 +2,5 @@
 /node_modules
 /coverage
 /cache
+/docs
 /.nyc_output

--- a/umbra-js/README.md
+++ b/umbra-js/README.md
@@ -222,7 +222,7 @@ if (tokenAddress === ETH_ADDRESS) {
 
 ## API Reference
 
-For a full API reference, navigate to the `umbra-js` folder in your terminal and run `yarn typedoc src/`. Open
+For a full API reference, navigate to the `umbra-js` folder in your terminal and run `yarn docs`. Open
 the resulting `umbra-js/docs/index.html` file in your browser to view the documentation.
 
 ## Development

--- a/umbra-js/README.md
+++ b/umbra-js/README.md
@@ -126,7 +126,7 @@ import { signer } from "the/users/connected/wallet"; // assume user previously c
 // Prompt the user for their signature to get their private keys
 const {
   spendingKeyPair,
-  viewingKeyPair
+  viewingKeyPair,
 } = await umbra.value.generatePrivateKeys(signer.value);
 
 // Define a custom range of blocks to scan. Leave this parameter out to scan all blocks
@@ -160,7 +160,7 @@ const ETH_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 // Prompt the user for their signature to get their private keys
 const {
   spendingKeyPair,
-  viewingKeyPair
+  viewingKeyPair,
 } = await umbra.value.generatePrivateKeys(signer.value);
 
 // Let's assume we're working with the first announcement outputs from the above snippet

--- a/umbra-js/package.json
+++ b/umbra-js/package.json
@@ -17,7 +17,8 @@
     "clean": "rimraf build coverage .nyc_output cache",
     "prepare": "yarn build",
     "prepublishOnly": "yarn lint && yarn test",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "docs": "typedoc src/"
   },
   "author": "Matt Solomon <matt@mattsolomon.dev>, Ben DiFrancesco <ben@scopelift.co>",
   "license": "ISC",

--- a/umbra-js/src/classes/Umbra.ts
+++ b/umbra-js/src/classes/Umbra.ts
@@ -190,11 +190,15 @@ export class Umbra {
    * @dev The provider used for sending the transaction is the one associated with the Umbra instance
    * @dev This method does not relay meta-transactions and requires signer to have ETH
    * @param spendingPrivateKey Receiver's spending private key
-   * @param token Address of token to withdraw
+   * @param token Address of token to withdraw,
    * @param destination Address where funds will be withdrawn to
    * @param overrides Override the gas limit, gas price, or nonce
    */
   async withdraw(spendingPrivateKey: string, token: string, destination: string, overrides: Overrides = {}) {
+    // Address input validations
+    // token === 'ETH' is valid so we don't verify that, and let ethers verify it during the function call
+    destination = getAddress(destination);
+
     // Configure signer
     const stealthWallet = new Wallet(spendingPrivateKey); // validates spendingPrivateKey input
     const txSigner = this.getConnectedSigner(stealthWallet);
@@ -250,6 +254,13 @@ export class Umbra {
     s: string,
     overrides: Overrides = {}
   ) {
+    // Address input validations
+    stealthAddr = getAddress(stealthAddr);
+    destination = getAddress(destination);
+    token = getAddress(token);
+    sponsor = getAddress(sponsor);
+
+    // Send withdraw transaction
     const txSigner = this.getConnectedSigner(signer);
     return await this.umbraContract
       .connect(txSigner)
@@ -300,7 +311,7 @@ export class Umbra {
         const computedReceivingAddress = spendingKeyPair.mulPublicKey(randomNumber).address;
 
         // If our receiving address matches the event's recipient, the transfer was for us
-        if (computedReceivingAddress === receiver) {
+        if (computedReceivingAddress === getAddress(receiver)) {
           const [block, tx, receipt] = await Promise.all([
             event.getBlock(),
             event.getTransaction(),
@@ -311,7 +322,7 @@ export class Umbra {
             randomNumber,
             receiver,
             amount,
-            token,
+            token: getAddress(token),
             block,
             tx,
             receipt,
@@ -429,7 +440,7 @@ export class Umbra {
     hook: string = AddressZero,
     data = '0x'
   ) {
-    // Validate addresses
+    // Address input validations
     contract = getAddress(contract);
     acceptor = getAddress(acceptor);
     sponsor = getAddress(sponsor);

--- a/umbra-js/src/utils/utils.ts
+++ b/umbra-js/src/utils/utils.ts
@@ -7,6 +7,7 @@ import {
   Contract,
   ContractInterface,
   EtherscanProvider,
+  getAddress,
   isHexString,
   keccak256,
   resolveProperties,
@@ -82,6 +83,7 @@ export async function recoverPublicKeyFromTransaction(txHash: string, provider: 
  * @param provider ethers provider instance
  */
 async function getSentTransaction(address: string, ethersProvider: EthersProvider) {
+  address = getAddress(address); // address input validation
   const network = await ethersProvider.getNetwork();
   const etherscanProvider = new EtherscanProvider(network.chainId);
   const history = await etherscanProvider.getHistory(address);
@@ -119,7 +121,7 @@ export async function lookupRecipient(id: string, provider: EthersProvider) {
   const isValidAddress = id.length === 42 && isHexString(id);
   if (isValidAddress) {
     // Get last transaction hash sent by that address
-    const txHash = await getSentTransaction(id, provider);
+    const txHash = await getSentTransaction(getAddress(id), provider);
     if (!txHash) {
       throw new Error('Could not get public key because the provided address has not sent any transactions');
     }


### PR DESCRIPTION
- Adds a few `getAddress` checks to validate addresses + ensure we always use checksum addresses
- Add script to `package.json` to simplify umbra-js doc generation
- Add files/folders to eslintignore—the umbra-js `yarn lint` was failing and this fixes that
- In `Umbra.sol`, `ETH_TOKEN_PLACHOLDER` did not have it's visibility specified, so made it public
- Ran Prettier which formatted the README