### PR TITLE
umbra-js security improvements

### DIFF
--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -86,9 +86,6 @@
                   <span>{{ col.value.from }}</span>
                   <q-icon class="copy-icon" name="far fa-copy" right />
                 </div>
-                <div v-if="hasPayloadExtension(props.row.randomNumber)" class="text-caption text-grey">
-                  {{ formatPayloadExtensionText(props.row.randomNumber) }}
-                </div>
               </div>
 
               <!-- Default -->
@@ -203,15 +200,7 @@
 <script lang="ts">
 import { computed, defineComponent, onMounted, PropType, ref } from '@vue/composition-api';
 import { date, copyToClipboard } from 'quasar';
-import {
-  arrayify,
-  BigNumber,
-  Block,
-  joinSignature,
-  formatUnits,
-  toUtf8String,
-  TransactionResponse,
-} from 'src/utils/ethers';
+import { BigNumber, Block, joinSignature, formatUnits, TransactionResponse } from 'src/utils/ethers';
 import { DomainService, Umbra, UserAnnouncement, KeyPair } from '@umbra/umbra-js';
 import useSettingsStore from 'src/store/settings';
 import useWalletStore from 'src/store/wallet';
@@ -298,9 +287,6 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
   // Table formatters and helpers
   const formatDate = (timestamp: number) => date.formatDate(timestamp, 'YYYY-MM-DD');
   const formatTime = (timestamp: number) => date.formatDate(timestamp, 'h:mm A');
-  const zeroPrefix = '0x00000000000000000000000000000000'; // 16 bytes of zeros
-  const hasPayloadExtension = (randomNumber: string) => randomNumber.slice(0, 34) !== zeroPrefix;
-  const formatPayloadExtensionText = (randomNumber: string) => toUtf8String(arrayify(randomNumber.slice(0, 34)));
   const isEth = (tokenAddress: string) => tokenAddress === '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
   const getTokenInfo = (tokenAddress: string) => tokens.value.filter((token) => token.address === tokenAddress)[0];
   const getStealthBalance = async (tokenAddress: string, userAddress: string) => {
@@ -465,14 +451,12 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
     expanded,
     formatAmount,
     formatDate,
-    formatPayloadExtensionText,
     formattedAnnouncements,
     formatTime,
     formatUnits,
     getFeeEstimate,
     getTokenLogoUri,
     getTokenSymbol,
-    hasPayloadExtension,
     initializeWithdraw,
     isEth,
     isFeeLoading,

--- a/frontend/src/utils/ethers.ts
+++ b/frontend/src/utils/ethers.ts
@@ -6,19 +6,12 @@
 
 export { getAddress } from '@ethersproject/address';
 export { BigNumber } from '@ethersproject/bignumber';
-export { hexZeroPad, arrayify, hexlify, isHexString, joinSignature } from '@ethersproject/bytes';
+export { isHexString, joinSignature } from '@ethersproject/bytes';
 export { AddressZero, MaxUint256 } from '@ethersproject/constants';
 export { Contract } from '@ethersproject/contracts';
 export { namehash } from '@ethersproject/hash';
 export { keccak256 } from '@ethersproject/keccak256';
-export {
-  Block,
-  ExternalProvider,
-  JsonRpcSigner,
-  Network,
-  TransactionReceipt,
-  TransactionResponse,
-  Web3Provider,
-} from '@ethersproject/providers';
-export { toUtf8Bytes, toUtf8String } from '@ethersproject/strings';
+// prettier-ignore
+export { Block, JsonRpcSigner, Network, TransactionReceipt, TransactionResponse, Web3Provider, } from '@ethersproject/providers';
+export { toUtf8Bytes } from '@ethersproject/strings';
 export { parseUnits, formatUnits } from '@ethersproject/units';

--- a/umbra-js/src/classes/DomainService.ts
+++ b/umbra-js/src/classes/DomainService.ts
@@ -60,11 +60,11 @@ export class DomainService {
    * @param viewingPublicKey The public key to use for encryption as hex string
    * @returns Transaction hash
    */
-  async setPublicKeys(name: string, spendingPrivateKey: string, viewingPrivateKey: string) {
+  async setPublicKeys(name: string, spendingPublicKey: string, viewingPublicKey: string) {
     if (ens.isEnsDomain(name)) {
-      return ens.setPublicKeys(name, spendingPrivateKey, viewingPrivateKey, this.provider);
+      return ens.setPublicKeys(name, spendingPublicKey, viewingPublicKey, this.provider);
     } else {
-      return cns.setPublicKeys(name, spendingPrivateKey, viewingPrivateKey, this.provider, this.udResolution);
+      return cns.setPublicKeys(name, spendingPublicKey, viewingPublicKey, this.provider, this.udResolution);
     }
   }
 }

--- a/umbra-js/src/classes/RandomNumber.ts
+++ b/umbra-js/src/classes/RandomNumber.ts
@@ -1,54 +1,35 @@
 /**
- * @dev Class for managing random numbers. In Umbra, a random number is 32 bytes, where
- * the first 16 bytes are zeros (optionally used by developers as payload extensions), and the
- * last 16 bytes are the random number
+ * @dev Class for managing random numbers
+ * @dev In the Umbra Protocol, all random numbers should be 32 bytes to ensure sufficient security
  */
 
-import { BigNumber, hexZeroPad, isHexString } from '../ethers';
+import { BigNumber, hexZeroPad } from '../ethers';
 import { utils } from 'noble-secp256k1';
 
-const zeroPrefix = '0x00000000000000000000000000000000'; // 16 bytes of zeros
-
 export class RandomNumber {
-  readonly randomLength = 16; // 16 bytes of randomness
-  readonly fullLength = 32; // pad to number to 32 bytes
+  readonly sizeInBytes = 32; // generated random number will always be 32 bytes
   readonly value: BigNumber; // random number value
 
   /**
-   * @notice Generate a new random number
-   * @param payloadExtension 16 byte payload extension, with 0x prefix. Specify as a 34 character
-   * hex string where the first two characters are 0x
+   * @notice Generate a new 32 byte random number
    */
-  constructor(readonly payloadExtension: string = zeroPrefix) {
-    // Validate payload extension
-    if (!isHexString(payloadExtension)) {
-      throw new Error('Payload extension is not a valid hex string');
-    }
-    if (payloadExtension.length !== 34) {
-      throw new Error('Payload extension must be a 16 byte hex string with the 0x prefix');
-    }
-
-    // Generate default random number without payload extension
-    const randomNumberAsBytes = utils.randomPrivateKey(this.randomLength);
+  constructor() {
+    // Randomly generate 32 bytes and save them as a BigNumber
+    const randomNumberAsBytes = utils.randomPrivateKey(this.sizeInBytes);
     this.value = BigNumber.from(randomNumberAsBytes);
-
-    // Payload extension is valid, so update the random number. If no payload extension is provided
-    // the below is equivalent doing nothing, as it replaces the zero prefix with the zero prefix
-    const randomNumberAsHexWithPayloadExt = this.asHex.replace(zeroPrefix, payloadExtension);
-    this.value = BigNumber.from(randomNumberAsHexWithPayloadExt);
   }
 
   /**
    * @notice Get random number as hex string
    */
   get asHex() {
-    return hexZeroPad(this.value.toHexString(), this.fullLength);
+    return hexZeroPad(this.value.toHexString(), this.sizeInBytes);
   }
 
   /**
    * @notice Get random number as hex string without 0x prefix
    */
   get asHexSlim() {
-    return hexZeroPad(this.asHex, this.fullLength).slice(2);
+    return hexZeroPad(this.asHex, this.sizeInBytes).slice(2);
   }
 }

--- a/umbra-js/src/classes/Umbra.ts
+++ b/umbra-js/src/classes/Umbra.ts
@@ -151,7 +151,7 @@ export class Umbra {
     const viewingKeyPair = new KeyPair(viewingPublicKey);
 
     // Generate random number
-    const randomNumber = overrides.payloadExtension ? new RandomNumber(overrides.payloadExtension) : new RandomNumber();
+    const randomNumber = new RandomNumber();
 
     // Encrypt random number with recipient's public key
     const encrypted = viewingKeyPair.encrypt(randomNumber);
@@ -165,19 +165,15 @@ export class Umbra {
     // Ensure that the stealthKeyPair's address is not on the block list
     if (blockedStealthAddresses.includes(stealthKeyPair.address)) throw new Error('Invalid stealth address');
 
-    // Get overrides object that removes the payload extension, for use with ethers
-    const filteredOverrides = { ...overrides };
-    delete filteredOverrides.payloadExtension;
-
     // Send transaction
     let tx: ContractTransaction;
     if (isEth(token)) {
-      const txOverrides = { ...filteredOverrides, value: toll.add(amount) };
+      const txOverrides = { ...overrides, value: toll.add(amount) };
       tx = await this.umbraContract
         .connect(txSigner)
         .sendEth(stealthKeyPair.address, toll, pubKeyXCoordinate, encrypted.ciphertext, txOverrides);
     } else {
-      const txOverrides = { ...filteredOverrides, value: toll };
+      const txOverrides = { ...overrides, value: toll };
       tx = await this.umbraContract
         .connect(txSigner)
         .sendToken(stealthKeyPair.address, token, amount, pubKeyXCoordinate, encrypted.ciphertext, txOverrides);

--- a/umbra-js/src/types.ts
+++ b/umbra-js/src/types.ts
@@ -38,7 +38,8 @@ export interface CompressedPublicKey {
 
 // Overrides when sending funds
 export interface SendOverrides extends Overrides {
-  payloadExtension?: string;
+  // SendOverrides is the same as the standard Overrides, but defined as its own type for clarity and
+  // potential future extensibility
 }
 
 // Overrides for the start and end block numbers to use when scanning for events

--- a/umbra-js/test/KeyPair.test.ts
+++ b/umbra-js/test/KeyPair.test.ts
@@ -1,8 +1,6 @@
 import * as chai from 'chai';
 import { ethers } from 'hardhat';
 import { Wallet } from 'ethers';
-import { BigNumber, hexZeroPad } from '../src/ethers';
-import { randomBytes } from '@ethersproject/random';
 import { RandomNumber } from '../src/classes/RandomNumber';
 import { KeyPair } from '../src/classes/KeyPair';
 import { Umbra } from '../src/classes/Umbra';
@@ -12,23 +10,11 @@ import { expectRejection } from './utils';
 const { expect } = chai;
 const ethersProvider = ethers.provider;
 const numberOfRuns = 100; // number of runs for tests that execute in a loop
-const zeroPrefix = '0x00000000000000000000000000000000'; // 16 bytes of zeros
 
 // Address, public key (not used), and private key from first deterministic ganache account
 const address = '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1';
 // const publicKey = '0x04e68acfc0253a10620dff706b0a1b1f1f5833ea3beb3bde2250d5f271f3563606672ebc45e0b7ea2e816ecb70ca03137b1c9476eec63d4632e990020b7b6fba39';
 const privateKey = '0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d';
-
-// Generates a random number with a random payload extension if one is not provided
-const generateRandomNumber = (payloadExtension: string | undefined = undefined) => {
-  // If a payload extension was provided, use that
-  if (payloadExtension) {
-    return new RandomNumber(payloadExtension);
-  }
-  // Otherwise, generate a random one to use
-  const randomPayloadExtension = hexZeroPad(BigNumber.from(randomBytes(16)).toHexString(), 16);
-  return new RandomNumber(randomPayloadExtension);
-};
 
 describe('KeyPair class', () => {
   let wallet: Wallet;
@@ -159,16 +145,11 @@ describe('KeyPair class', () => {
     it('supports encryption and decryption of the random number', async () => {
       // Do a bunch of tests with random wallets and numbers
       for (let i = 0; i < numberOfRuns; i += 1) {
-        // Every 100th run, print status update and use the zero payload extension
-        let randomNumber: RandomNumber;
-        if ((i + 1) % 100 === 0) {
-          console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
-          randomNumber = generateRandomNumber(zeroPrefix);
-        } else {
-          randomNumber = generateRandomNumber();
-        }
+        // Every 100th run print status update
+        if ((i + 1) % 100 === 0) console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
 
         // Generate random wallet and encrypt payload
+        const randomNumber = new RandomNumber();
         const wallet = Wallet.createRandom();
         const keyPairFromPublic = new KeyPair(wallet.publicKey);
         const output = await keyPairFromPublic.encrypt(randomNumber); // eslint-disable-line no-await-in-loop
@@ -182,16 +163,11 @@ describe('KeyPair class', () => {
 
     it('lets sender generate stealth receiving address that recipient can access', () => {
       for (let i = 0; i < numberOfRuns; i += 1) {
-        // Every 100th run, print status update and use the zero payload extension
-        let randomNumber: RandomNumber;
-        if ((i + 1) % 100 === 0) {
-          console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
-          randomNumber = generateRandomNumber(zeroPrefix);
-        } else {
-          randomNumber = generateRandomNumber();
-        }
+        // Every 100th run print status update
+        if ((i + 1) % 100 === 0) console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
 
         // Sender computes receiving address from random number and recipient's public key
+        const randomNumber = new RandomNumber();
         const recipientFromPublic = new KeyPair(wallet.publicKey);
         const stealthFromPublic = recipientFromPublic.mulPublicKey(randomNumber);
 
@@ -208,15 +184,10 @@ describe('KeyPair class', () => {
     it('lets multiplication be performed with RandomNumber class or hex string', () => {
       for (let i = 0; i < numberOfRuns; i += 1) {
         // Every 100th run, print status update and use the zero payload extension
-        let randomNumber: RandomNumber;
-        if ((i + 1) % 100 === 0) {
-          randomNumber = generateRandomNumber(zeroPrefix);
-          console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
-        } else {
-          randomNumber = generateRandomNumber();
-        }
+        if ((i + 1) % 100 === 0) console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
 
-        // Generate random wallet
+        // Generate random number and wallet
+        const randomNumber = new RandomNumber();
         const randomWallet = Wallet.createRandom();
         const randomFromPublic = new KeyPair(randomWallet.publicKey);
         const randomFromPrivate = new KeyPair(randomWallet.privateKey);
@@ -241,15 +212,10 @@ describe('KeyPair class', () => {
       let numFailures = 0;
       for (let i = 0; i < numberOfRuns; i += 1) {
         // Every 100th run, print status update and use the zero payload extension
-        let randomNumber: RandomNumber;
-        if ((i + 1) % 100 === 0) {
-          console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
-          randomNumber = generateRandomNumber(zeroPrefix);
-        } else {
-          randomNumber = generateRandomNumber();
-        }
+        if ((i + 1) % 100 === 0) console.log(`Executing run ${i + 1} of ${numberOfRuns}...`);
 
-        // Generate random wallet
+        // Generate random number and wallet
+        const randomNumber = new RandomNumber();
         const randomWallet = Wallet.createRandom();
 
         // Sender computes receiving address from random number and recipient's public key

--- a/umbra-js/test/RandomNumber.test.ts
+++ b/umbra-js/test/RandomNumber.test.ts
@@ -1,11 +1,9 @@
 import { RandomNumber } from '../src/classes/RandomNumber';
 import * as chai from 'chai';
-import { BigNumber, hexZeroPad, isHexString } from '../src/ethers';
-import { randomBytes } from '@ethersproject/random';
+import { BigNumber, isHexString } from '../src/ethers';
 
 const { expect } = chai;
 const numberOfRuns = 1000; // number of runs for tests that execute in a loop
-const zeroPrefix = '00000000000000000000000000000000'; // 16 bytes of zeros
 
 describe('RandomNumber class', () => {
   let random: RandomNumber;
@@ -19,18 +17,12 @@ describe('RandomNumber class', () => {
     expect(value.constructor).to.equal(BigNumber);
   });
 
-  it('returns random value as a 32 byte hex string with 16 bytes of leading zeros', () => {
+  it('returns random value as a 32 byte hex string', () => {
     for (let i = 0; i < numberOfRuns; i += 1) {
       random = new RandomNumber();
       const hex = random.asHex;
-      const first16Bytes = hex.slice(2, 34);
-      const last16Bytes = hex.slice(34);
-
       expect(isHexString(hex)).to.be.true;
       expect(hex.length).to.equal(66); // 32 bytes plus leading 0x prefix
-      expect(first16Bytes).to.equal(zeroPrefix);
-      expect(last16Bytes).to.not.equal(zeroPrefix);
-      expect(`0x${first16Bytes}${last16Bytes}`).to.equal(hex);
     }
   });
 
@@ -38,14 +30,8 @@ describe('RandomNumber class', () => {
     for (let i = 0; i < numberOfRuns; i += 1) {
       random = new RandomNumber();
       const hex = random.asHexSlim;
-      const first16Bytes = hex.slice(0, 32);
-      const last16Bytes = hex.slice(32);
-
       expect(isHexString(hex)).to.be.false;
       expect(hex.length).to.equal(64); // 32 bytes without 0x prefix
-      expect(first16Bytes).to.equal(zeroPrefix);
-      expect(last16Bytes).to.not.equal(zeroPrefix);
-      expect(`${first16Bytes}${last16Bytes}`).to.equal(hex);
     }
   });
 
@@ -60,45 +46,5 @@ describe('RandomNumber class', () => {
 
     expect(first16Bytes).to.equal(first16BytesSlim);
     expect(last16Bytes).to.equal(last16BytesSlim);
-  });
-
-  it('throws if the payload extension is not a valid hex string', () => {
-    let badFunction;
-    const errorMessage1 = 'Payload extension is not a valid hex string';
-    const errorMessage2 = 'Payload extension must be a 16 byte hex string with the 0x prefix';
-
-    // Not a hex string
-    badFunction = () => new RandomNumber('thisShouldThrow');
-    expect(badFunction).to.throw(errorMessage1);
-
-    // Hex string of correct size, but missing 0x prefix
-    badFunction = () => new RandomNumber('ff2e6c8b7a2532a03cc70417e25084b6');
-    expect(badFunction).to.throw(errorMessage1);
-
-    // Properly formatted hex string, but wrong size
-    badFunction = () => new RandomNumber('0x123');
-    expect(badFunction).to.throw(errorMessage2);
-    badFunction = () => new RandomNumber('0xff2e6c8b7a2532a03cc70417e25084b6ff');
-    expect(badFunction).to.throw(errorMessage2);
-  });
-
-  it('lets the user set a payload extension when generating a random number', () => {
-    for (let i = 0; i < numberOfRuns; i += 1) {
-      // Generate random hex string with the correct format
-      const randomHexString = hexZeroPad(BigNumber.from(randomBytes(16)).toHexString(), 16);
-
-      random = new RandomNumber(randomHexString);
-      const hex = random.asHex;
-      const hexSlim = random.asHexSlim;
-      const first16Bytes = hexSlim.slice(0, 32);
-      const last16Bytes = hexSlim.slice(32);
-
-      expect(isHexString(hex)).to.be.true;
-      expect(hex.length).to.equal(66); // 32 bytes plus leading
-      expect(first16Bytes).to.equal(randomHexString.slice(2));
-      expect(first16Bytes).to.not.equal(zeroPrefix);
-      expect(last16Bytes).to.not.equal(randomHexString.slice(2));
-      expect(last16Bytes).to.not.equal(zeroPrefix);
-    }
   });
 });

--- a/umbra-js/test/Umbra.test.ts
+++ b/umbra-js/test/Umbra.test.ts
@@ -21,7 +21,6 @@ const ethersProvider = ethers.provider;
 const jsonRpcProvider = new JsonRpcProvider(hardhatConfig.networks?.hardhat?.forking?.url);
 
 const ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
-const payloadExtension = '0x0123456789abcdef0123456789abcdef';
 const quantity = parseEther('5');
 
 // We don't use the 0 or 1 index just to reduce the chance of conflicting with a signer for another use case
@@ -212,9 +211,7 @@ describe('Umbra class', () => {
       await mintAndApproveDai(sender, sender.address, quantity);
 
       // Send funds with Umbra
-      const { tx, stealthKeyPair } = await umbra.send(sender, dai.address, quantity, receiver!.publicKey, {
-        payloadExtension,
-      });
+      const { tx, stealthKeyPair } = await umbra.send(sender, dai.address, quantity, receiver!.publicKey);
       await tx.wait();
 
       // RECEIVER
@@ -287,9 +284,7 @@ describe('Umbra class', () => {
     it('With payload extension: send ETH, scan for it, withdraw it', async () => {
       // SENDER
       // Send funds with Umbra
-      const { tx, stealthKeyPair } = await umbra.send(sender, ETH_ADDRESS, quantity, receiver.publicKey, {
-        payloadExtension,
-      });
+      const { tx, stealthKeyPair } = await umbra.send(sender, ETH_ADDRESS, quantity, receiver.publicKey);
       await tx.wait();
 
       // RECEIVER

--- a/umbra-js/test/utils.test.ts
+++ b/umbra-js/test/utils.test.ts
@@ -13,6 +13,11 @@ const publicKey =
   '0x04df3d784d6d1e55fabf44b7021cf17c00a6cccc53fea00d241952ac2eebc46dc674c91e60ccd97576c1ba2a21beed21f7b02aee089f2eeec357ffd349488a7cee';
 const publicKeys = { spendingPublicKey: publicKey, viewingPublicKey: publicKey };
 
+// Define public key that is not on the curve. This point was generated from a valid public key ending in
+// `83b3` and we took this off the curve by changing the final digits to `83b4`
+const badPublicKey =
+  '0x04059f2fa86c55b95a8db142a6a5490c43e242d03ed8c0bd58437a98709dc9e18b3bddafce903ea49a44b78d57626448c83f8649d3ec4e7c72d8777823f49583b4';
+
 describe('Utilities', () => {
   describe('Helpers', () => {
     it('recovers public keys from transactions', async () => {
@@ -68,6 +73,10 @@ describe('Utilities', () => {
       expect(keys.viewingPublicKey).to.equal(
         '0x041190b7e2b61b8872c9ea5fff14770e7d3e78900282371b09ee9f2b8c4016b9967b5e9ee9e1e0bef30052e806321f0685a3ad69e2233be6813b81a5d293feea76'
       );
+    });
+
+    it('throws when given a public key not on the curve', async () => {
+      await expectRejection(utils.lookupRecipient(badPublicKey, ethersProvider), 'Point is not on elliptic curve');
     });
   });
 


### PR DESCRIPTION
Contingent on https://github.com/ScopeLift/umbra-protocol/pull/176 being merged first, since this builds off that PR (hence all the extra commits)

**Random Number Fixes** 
- `RandomNumber` class ignores payload extension input (for now) and always generates 32 byte random numbers
- Memo field was removed from the send form

**Point validation**
- Adds a new utility method in umbra-js called `assertValidPoint()` which verifies that a point is on the secp256k1 curve

**Other**
- I noticed wrongly named function inputs in `DomainService.ts`, so fixed that also