### PR TITLE
Frontend tweaks

### DIFF
--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -156,7 +156,7 @@
                     <div v-else-if="activeFee" class="text-caption">
                       Estimated withdrawal fee:
                       <span class="text-bold">
-                        {{ formatUnits(activeFee.fee, activeFee.token.decimals) }}
+                        {{ round(formatUnits(activeFee.fee, activeFee.token.decimals)) }}
                         {{ activeFee.token.symbol }}
                       </span>
                     </div>
@@ -211,7 +211,7 @@ import AccountReceiveTableWarning from 'components/AccountReceiveTableWarning.vu
 import AccountReceiveTableWithdrawConfirmation from 'components/AccountReceiveTableWithdrawConfirmation.vue';
 import { ConfirmedITXStatusResponse, FeeEstimateResponse } from 'components/models';
 import { lookupOrFormatAddresses, toAddress, isAddressSafe } from 'src/utils/address';
-import { getEtherscanUrl } from 'src/utils/utils';
+import { getEtherscanUrl, round } from 'src/utils/utils';
 
 function useAdvancedFeatures(spendingKeyPair: KeyPair) {
   const { startBlock, endBlock, scanPrivateKey } = useSettingsStore();
@@ -475,6 +475,7 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
     openInEtherscan,
     paginationConfig,
     privacyModalAddressDescription,
+    round,
     showConfirmationModal,
     showPrivacyModal,
     txHashIfEth,

--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -380,6 +380,7 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
    */
   async function executeWithdraw() {
     if (!umbra.value) throw new Error('Umbra instance not found');
+    if (!provider.value) throw new Error('Provider not found');
     if (!activeAnnouncement.value) throw new Error('No announcement is selected for withdraw');
     showPrivacyModal.value = false;
 
@@ -396,7 +397,9 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
       let tx: TransactionResponse;
       if (token.symbol === 'ETH') {
         // Withdrawing ETH
-        tx = await umbra.value.withdraw(spendingPrivateKey, token.address, acceptor);
+        const lowGasPrice = await provider.value.getGasPrice(); // returns roughly a median
+        const gasPrice = lowGasPrice.mul('110').div('100'); // bump gas price by 10%
+        tx = await umbra.value.withdraw(spendingPrivateKey, token.address, acceptor, { gasPrice });
         txNotify(tx.hash);
         await tx.wait();
       } else {

--- a/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
+++ b/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
@@ -61,7 +61,7 @@ import { computed, defineComponent, PropType } from '@vue/composition-api';
 import { UserAnnouncement } from '@umbra/umbra-js';
 import { FeeEstimate } from 'components/models';
 import { BigNumber, formatUnits } from 'src/utils/ethers';
-import { getEtherscanUrl } from 'src/utils/utils';
+import { getEtherscanUrl, round } from 'src/utils/utils';
 
 export default defineComponent({
   name: 'AccountReceiveTableWithdrawConfirmation',
@@ -104,9 +104,9 @@ export default defineComponent({
     const amountReceived = BigNumber.from(amount).sub(fee).toString();
     const decimals = props.activeFee.token.decimals;
     const symbol = props.activeFee.token.symbol;
-    const formattedAmount = formatUnits(amount, decimals);
-    const formattedFee = formatUnits(fee, decimals);
-    const formattedAmountReceived = formatUnits(amountReceived, decimals);
+    const formattedAmount = round(formatUnits(amount, decimals));
+    const formattedFee = round(formatUnits(fee, decimals));
+    const formattedAmountReceived = round(formatUnits(amountReceived, decimals));
     const canWithdraw = BigNumber.from(amount).gt(fee);
     const tokenURL = props.activeFee.token.logoURI;
     const isEth = props.activeFee.token.symbol === 'ETH';

--- a/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
+++ b/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
@@ -48,16 +48,20 @@
       <div v-else class="text-center">
         <q-spinner-puff class="q-mb-md" color="primary" size="2rem" />
         <div class="text-center text-italic">Withdraw in progress...</div>
+        <a v-if="txHash.length === 66" class="text-caption hyperlink" :href="etherscanUrl" target="_blank">
+          View transaction <q-icon name="fas fa-external-link-alt" right />
+        </a>
       </div>
     </q-card-section>
   </q-card>
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from '@vue/composition-api';
+import { computed, defineComponent, PropType } from '@vue/composition-api';
 import { UserAnnouncement } from '@umbra/umbra-js';
 import { FeeEstimate } from 'components/models';
 import { BigNumber, formatUnits } from 'src/utils/ethers';
+import { getEtherscanUrl } from 'src/utils/utils';
 
 export default defineComponent({
   name: 'AccountReceiveTableWithdrawConfirmation',
@@ -73,6 +77,11 @@ export default defineComponent({
       required: true,
     },
 
+    chainId: {
+      type: Number,
+      required: true,
+    },
+
     destinationAddress: {
       type: String,
       required: true,
@@ -80,6 +89,11 @@ export default defineComponent({
 
     isWithdrawInProgress: {
       type: Boolean,
+      required: true,
+    },
+
+    txHash: {
+      type: String,
       required: true,
     },
   },
@@ -96,7 +110,18 @@ export default defineComponent({
     const canWithdraw = BigNumber.from(amount).gt(fee);
     const tokenURL = props.activeFee.token.logoURI;
     const isEth = props.activeFee.token.symbol === 'ETH';
-    return { context, canWithdraw, formattedAmount, formattedFee, formattedAmountReceived, symbol, tokenURL, isEth };
+    const etherscanUrl = computed(() => getEtherscanUrl(props.txHash, props.chainId));
+    return {
+      canWithdraw,
+      context,
+      etherscanUrl,
+      formattedAmount,
+      formattedAmountReceived,
+      formattedFee,
+      isEth,
+      symbol,
+      tokenURL,
+    };
   },
 });
 </script>

--- a/frontend/src/components/BaseSelect.vue
+++ b/frontend/src/components/BaseSelect.vue
@@ -31,7 +31,7 @@
       <template v-slot:option="scope">
         <q-item v-bind="scope.itemProps" v-on="scope.itemEvents">
           <q-item-section avatar v-if="scope.opt.logoURI">
-            <img :src="scope.opt.logoURI" height="25rem" />
+            <img class="horizontal-center" :src="scope.opt.logoURI" height="25rem" />
           </q-item-section>
           <q-item-section>
             <q-item-label v-html="scope.opt[optionLabel]" />

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -1,0 +1,9 @@
+export const getEtherscanUrl = (txHash: string, chainId: number) => {
+  let networkPrefix = ''; // assume mainnet by default
+  if (chainId === 1) networkPrefix = '';
+  if (chainId === 3) networkPrefix = 'ropsten.';
+  if (chainId === 4) networkPrefix = 'rinkeby.';
+  if (chainId === 5) networkPrefix = 'goerli.';
+  if (chainId === 42) networkPrefix = 'kovan.';
+  return `https://${networkPrefix}etherscan.io/tx/${txHash}`;
+};

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -7,3 +7,5 @@ export const getEtherscanUrl = (txHash: string, chainId: number) => {
   if (chainId === 42) networkPrefix = 'kovan.';
   return `https://${networkPrefix}etherscan.io/tx/${txHash}`;
 };
+
+export const round = (value: number | string, decimals = 2) => Number(value).toFixed(decimals);


### PR DESCRIPTION
- [x] Default to 10% higher than provider.getGasPrice()
- [x] Show ETH withdraw transaction hash in "Confirm Withdrawal" modal
- [x] Center logos in send form
- [x] Round fee estimate to 2 decimals in Receive table
- [x] Round all numbers to 2 decimals in "Confirm Withdrawal" modal
- [ ] Add logs + ability to set log level with Winston
- [ ] Let user enter gas price on ETH withdraw
- [ ] Auto-advance when selecting CNS (resolves #181)
- [ ] Update step 1 header to something like "Username Setup" (resolves #181)