### PR TITLE
Choose gas price on ETH withdrawals

### DIFF
--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -380,8 +380,8 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
   }
 
   type ExecuteWithdrawalOptions = {
-    gasPrice?: BigNumber // fee in wei
-  }
+    gasPrice?: BigNumber; // fee in wei
+  };
 
   /**
    * @notice Executes the withdraw process
@@ -404,7 +404,7 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
       isWithdrawInProgress.value = true;
       let tx: TransactionResponse;
       if (token.symbol === 'ETH') {
-        const {gasPrice} = options;
+        const { gasPrice } = options;
         tx = await umbra.value.withdraw(spendingPrivateKey, token.address, acceptor, { gasPrice });
         txHashIfEth.value = tx.hash;
         txNotify(tx.hash);

--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -379,10 +379,14 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
     showConfirmationModal.value = true;
   }
 
+  type ExecuteWithdrawalOptions = {
+    gasPrice?: BigNumber // fee in wei
+  }
+
   /**
    * @notice Executes the withdraw process
    */
-  async function executeWithdraw() {
+  async function executeWithdraw(options: ExecuteWithdrawalOptions) {
     if (!umbra.value) throw new Error('Umbra instance not found');
     if (!provider.value) throw new Error('Provider not found');
     if (!activeAnnouncement.value) throw new Error('No announcement is selected for withdraw');
@@ -400,9 +404,7 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
       isWithdrawInProgress.value = true;
       let tx: TransactionResponse;
       if (token.symbol === 'ETH') {
-        // Withdrawing ETH
-        const lowGasPrice = await provider.value.getGasPrice(); // returns roughly a median
-        const gasPrice = lowGasPrice.mul('110').div('100'); // bump gas price by 10%
+        const {gasPrice} = options;
         tx = await umbra.value.withdraw(spendingPrivateKey, token.address, acceptor, { gasPrice });
         txHashIfEth.value = tx.hash;
         txNotify(tx.hash);

--- a/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
+++ b/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
@@ -24,7 +24,8 @@
             @click="toggleCustomFee"
             color="primary"
             class="cursor-pointer q-ml-xs"
-            name="fas fa-times" />
+            name="fas fa-times"
+          />
         </div>
         <div v-else class="text-caption text-grey q-mt-md">Relayer Gas Fee</div>
         <div v-if="useCustomFee" class="row justify-start items-center">
@@ -32,7 +33,7 @@
             <img :src="tokenURL" class="q-mr-sm" style="height: 1rem" />
             <span class="text-danger">-{{ formattedCustomFeeEth }} {{ symbol }}</span>
           </div>
-          <div class="col-12" :style="{maxWidth: '200px'}">
+          <div class="col-12" :style="{ maxWidth: '200px' }">
             <base-input
               v-model="formattedCustomFee"
               type="number"
@@ -40,7 +41,7 @@
               :dense="true"
               :lazyRules="false"
               :rules="isValidFeeAmount"
-              >
+            >
             </base-input>
           </div>
         </div>
@@ -77,7 +78,8 @@
           @click="context.emit('confirmed', confirmationOptions)"
           class="q-ml-lg"
           :disable="!canWithdraw"
-          label="Confirm" />
+          label="Confirm"
+        />
       </div>
       <div v-else class="text-center">
         <q-spinner-puff class="q-mb-md" color="primary" size="2rem" />
@@ -158,12 +160,12 @@ export default defineComponent({
     const fee = ref<BigNumber | string>('0'); // default to a fee of zero
 
     const useCustomFee = ref<boolean>(false);
-    const toggleCustomFee = () => useCustomFee.value = !useCustomFee.value;
+    const toggleCustomFee = () => (useCustomFee.value = !useCustomFee.value);
     const formattedCustomFee = ref<BigNumber | string>('0'); // gas price in Gwei
     // the custom gas price; determines what gas price is actually used when withdrawing
     const customGasInWei = computed(() => {
       const customGasInGwei = formattedCustomFee.value ? formattedCustomFee.value : 0;
-      return BigNumber.from(customGasInGwei).mul(10**9);
+      return BigNumber.from(customGasInGwei).mul(10 ** 9);
     });
     const customFeeInWei = computed(() => {
       const transactionGasUsed = '21000';
@@ -173,41 +175,34 @@ export default defineComponent({
       round(formatUnits(customFeeInWei.value, decimals), ethDisplayDecimals)
     );
 
-    onMounted(
-      async () => {
-        if (isEth) {
-          const gasPrice = await getGasPrice();
-          const ethFee = BigNumber.from('21000').mul(gasPrice);
-          fee.value = ethFee;
-          // flooring this b/c the string we get back from formatUnits is a decimal
-          formattedCustomFee.value = Math.floor(formatUnits(gasPrice, 'gwei'));
-        } else {
-          fee.value = props.activeFee.fee;
-        }
-      }
-    );
-
-    // Define computed properties dependent on the fee (must be computed to react to ETH gas price updates by user).
-    // Variables prefixed with `formatted*` are inteded for display in the U)
-    const amountReceived = computed(
-      () => amount.sub(useCustomFee.value ? customFeeInWei.value : fee.value)
-    ); // amount user will receive
-    const formattedFee = computed(() => round(formatUnits(fee.value, decimals), numDecimals)); // relayer fee, rounded
-    const formattedAmountReceived = computed(
-      () => round(formatUnits(amountReceived.value, decimals), numDecimals)
-    ); // amount user will receive, rounded
-    // prevent withdraw attemps if fee is larger than amount
-    const canWithdraw = computed(() => (
-      BigNumber.from(amount).gt(useCustomFee.value ? customFeeInWei.value : fee.value)
-    ));
-    const confirmationOptions = computed(() => {
-      if (!isEth) return {}
-      return {
-        // fee is the total cost in wei for the gas, so we divide by the tx cost
-        gasPrice: useCustomFee.value ? customGasInWei.value : fee.value.div('21000')
+    onMounted(async () => {
+      if (isEth) {
+        const gasPrice = await getGasPrice();
+        const ethFee = BigNumber.from('21000').mul(gasPrice);
+        fee.value = ethFee;
+        // flooring this b/c the string we get back from formatUnits is a decimal
+        formattedCustomFee.value = Math.floor(formatUnits(gasPrice, 'gwei'));
+      } else {
+        fee.value = props.activeFee.fee;
       }
     });
 
+    // Define computed properties dependent on the fee (must be computed to react to ETH gas price updates by user).
+    // Variables prefixed with `formatted*` are inteded for display in the U)
+    const amountReceived = computed(() => amount.sub(useCustomFee.value ? customFeeInWei.value : fee.value)); // amount user will receive
+    const formattedFee = computed(() => round(formatUnits(fee.value, decimals), numDecimals)); // relayer fee, rounded
+    const formattedAmountReceived = computed(() => round(formatUnits(amountReceived.value, decimals), numDecimals)); // amount user will receive, rounded
+    // prevent withdraw attemps if fee is larger than amount
+    const canWithdraw = computed(() =>
+      BigNumber.from(amount).gt(useCustomFee.value ? customFeeInWei.value : fee.value)
+    );
+    const confirmationOptions = computed(() => {
+      if (!isEth) return {};
+      return {
+        // fee is the total cost in wei for the gas, so we divide by the tx cost
+        gasPrice: useCustomFee.value ? customGasInWei.value : fee.value.div('21000'),
+      };
+    });
 
     return {
       canWithdraw,

--- a/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
+++ b/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
@@ -28,6 +28,7 @@
               type="number"
               suffix="Gwei"
               :dense="true"
+              :lazyRules="false"
               :rules="isValidFeeAmount"
               >
             </base-input>

--- a/frontend/src/components/BaseInput.vue
+++ b/frontend/src/components/BaseInput.vue
@@ -139,7 +139,7 @@ export default Vue.extend({
     },
 
     placeholder: {
-      type: String|Number,
+      type: String | Number,
       required: false,
       default: undefined,
     },

--- a/frontend/src/components/BaseInput.vue
+++ b/frontend/src/components/BaseInput.vue
@@ -17,6 +17,7 @@
     :rules="[(val) => rules(val)]"
     :suffix="suffix"
     :type="type"
+    :min="type === 'number' ? 0 : undefined"
     :outlined="outlined"
     :placeholder="placeholder"
     standout
@@ -138,7 +139,7 @@ export default Vue.extend({
     },
 
     placeholder: {
-      type: String,
+      type: String|Number,
       required: false,
       default: undefined,
     },


### PR DESCRIPTION
Adds the following functionality:

<img src="https://user-images.githubusercontent.com/7997618/126827894-147f4c9a-5d00-4450-b646-6ab05d52b1c2.gif" width="50%" />

Tests were all manual.

Apart from the tests seen in the screenshot, I manually verified the following:
* token withdrawals still work ([tested DAI](https://rinkeby.etherscan.io/token/0x2e055eee18284513b993db7568a592679ab13188?a=0xde2087e6cd519a2fb7cf9e252b07cccb18a1f781))
* ETH withdrawals with default gas fees [still work](https://rinkeby.etherscan.io/tx/0x7eb347ce0f3bf5e18993fc92a5282f3b873fe714c806b4c78753a50f3cca4c21)

r? @mds1 