### PR TITLE
Disable withdrawal button if fee is zero/missing

### DIFF
--- a/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
+++ b/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
@@ -67,7 +67,7 @@
 
       <div v-if="!canWithdraw" class="border-warning q-mt-lg q-pa-md">
         <q-icon name="fas fa-exclamation-triangle" color="warning" left />
-        Cannot withdraw because fee is larger than amount
+        Cannot withdraw, please correct fee error
       </div>
     </q-card-section>
 
@@ -193,9 +193,10 @@ export default defineComponent({
     const formattedFee = computed(() => round(formatUnits(fee.value, decimals), numDecimals)); // relayer fee, rounded
     const formattedAmountReceived = computed(() => round(formatUnits(amountReceived.value, decimals), numDecimals)); // amount user will receive, rounded
     // prevent withdraw attemps if fee is larger than amount
-    const canWithdraw = computed(() =>
-      BigNumber.from(amount).gt(useCustomFee.value ? customFeeInWei.value : fee.value)
-    );
+    const canWithdraw = computed(() => {
+      const feeInWei = useCustomFee.value ? customFeeInWei.value : fee.value
+      return BigNumber.from(amount).gt(feeInWei) && BigNumber.from('0').lt(feeInWei)
+    });
     const confirmationOptions = computed(() => {
       if (!isEth) return {};
       return {


### PR DESCRIPTION
Adds the following functionality:

<img src="https://user-images.githubusercontent.com/7997618/127206866-df277770-ee69-485c-beb0-2b5d96e80b57.png" width="50%"/>


Tests were all manual.

I manually verified that [DAI](https://rinkeby.etherscan.io/tx/0xec206e938e9c40808d5ed9088d67eb5ca4518b7c158900f2af41dac49716a02d) and [ETH withdrawals](https://rinkeby.etherscan.io/tx/0x9194981a1393fe2a41511a1332656de5f0bad12f362605996f6b4b0c41e73a50) still work