### PR TITLE
Fronted features and fixes

### DIFF
--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -380,8 +380,8 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
   }
 
   type ExecuteWithdrawalOptions = {
-    gasPrice?: BigNumber // fee in wei
-  }
+    gasPrice?: BigNumber; // fee in wei
+  };
 
   /**
    * @notice Executes the withdraw process
@@ -404,7 +404,7 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
       isWithdrawInProgress.value = true;
       let tx: TransactionResponse;
       if (token.symbol === 'ETH') {
-        const {gasPrice} = options;
+        const { gasPrice } = options;
         tx = await umbra.value.withdraw(spendingPrivateKey, token.address, acceptor, { gasPrice });
         txHashIfEth.value = tx.hash;
         txNotify(tx.hash);

--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -379,10 +379,14 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
     showConfirmationModal.value = true;
   }
 
+  type ExecuteWithdrawalOptions = {
+    gasPrice?: BigNumber // fee in wei
+  }
+
   /**
    * @notice Executes the withdraw process
    */
-  async function executeWithdraw() {
+  async function executeWithdraw(options: ExecuteWithdrawalOptions) {
     if (!umbra.value) throw new Error('Umbra instance not found');
     if (!provider.value) throw new Error('Provider not found');
     if (!activeAnnouncement.value) throw new Error('No announcement is selected for withdraw');
@@ -400,9 +404,7 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
       isWithdrawInProgress.value = true;
       let tx: TransactionResponse;
       if (token.symbol === 'ETH') {
-        // Withdrawing ETH
-        const lowGasPrice = await provider.value.getGasPrice(); // returns roughly a median
-        const gasPrice = lowGasPrice.mul('110').div('100'); // bump gas price by 10%
+        const {gasPrice} = options;
         tx = await umbra.value.withdraw(spendingPrivateKey, token.address, acceptor, { gasPrice });
         txHashIfEth.value = tx.hash;
         txNotify(tx.hash);

--- a/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
+++ b/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
@@ -24,7 +24,8 @@
             @click="toggleCustomFee"
             color="primary"
             class="cursor-pointer q-ml-xs"
-            name="fas fa-times" />
+            name="fas fa-times"
+          />
         </div>
         <div v-else class="text-caption text-grey q-mt-md">Relayer Gas Fee</div>
         <div v-if="useCustomFee" class="row justify-start items-center">
@@ -32,7 +33,7 @@
             <img :src="tokenURL" class="q-mr-sm" style="height: 1rem" />
             <span class="text-danger">-{{ formattedCustomFeeEth }} {{ symbol }}</span>
           </div>
-          <div class="col-12" :style="{maxWidth: '200px'}">
+          <div class="col-12" :style="{ maxWidth: '200px' }">
             <base-input
               v-model="formattedCustomFee"
               type="number"
@@ -40,7 +41,7 @@
               :dense="true"
               :lazyRules="false"
               :rules="isValidFeeAmount"
-              >
+            >
             </base-input>
           </div>
         </div>
@@ -77,7 +78,8 @@
           @click="context.emit('confirmed', confirmationOptions)"
           class="q-ml-lg"
           :disable="!canWithdraw"
-          label="Confirm" />
+          label="Confirm"
+        />
       </div>
       <div v-else class="text-center">
         <q-spinner-puff class="q-mb-md" color="primary" size="2rem" />
@@ -158,12 +160,12 @@ export default defineComponent({
     const fee = ref<BigNumber | string>('0'); // default to a fee of zero
 
     const useCustomFee = ref<boolean>(false);
-    const toggleCustomFee = () => useCustomFee.value = !useCustomFee.value;
+    const toggleCustomFee = () => (useCustomFee.value = !useCustomFee.value);
     const formattedCustomFee = ref<BigNumber | string>('0'); // gas price in Gwei
     // the custom gas price; determines what gas price is actually used when withdrawing
     const customGasInWei = computed(() => {
       const customGasInGwei = formattedCustomFee.value ? formattedCustomFee.value : 0;
-      return BigNumber.from(customGasInGwei).mul(10**9);
+      return BigNumber.from(customGasInGwei).mul(10 ** 9);
     });
     const customFeeInWei = computed(() => {
       const transactionGasUsed = '21000';
@@ -173,41 +175,34 @@ export default defineComponent({
       round(formatUnits(customFeeInWei.value, decimals), ethDisplayDecimals)
     );
 
-    onMounted(
-      async () => {
-        if (isEth) {
-          const gasPrice = await getGasPrice();
-          const ethFee = BigNumber.from('21000').mul(gasPrice);
-          fee.value = ethFee;
-          // flooring this b/c the string we get back from formatUnits is a decimal
-          formattedCustomFee.value = Math.floor(formatUnits(gasPrice, 'gwei'));
-        } else {
-          fee.value = props.activeFee.fee;
-        }
-      }
-    );
-
-    // Define computed properties dependent on the fee (must be computed to react to ETH gas price updates by user).
-    // Variables prefixed with `formatted*` are inteded for display in the U)
-    const amountReceived = computed(
-      () => amount.sub(useCustomFee.value ? customFeeInWei.value : fee.value)
-    ); // amount user will receive
-    const formattedFee = computed(() => round(formatUnits(fee.value, decimals), numDecimals)); // relayer fee, rounded
-    const formattedAmountReceived = computed(
-      () => round(formatUnits(amountReceived.value, decimals), numDecimals)
-    ); // amount user will receive, rounded
-    // prevent withdraw attemps if fee is larger than amount
-    const canWithdraw = computed(() => (
-      BigNumber.from(amount).gt(useCustomFee.value ? customFeeInWei.value : fee.value)
-    ));
-    const confirmationOptions = computed(() => {
-      if (!isEth) return {}
-      return {
-        // fee is the total cost in wei for the gas, so we divide by the tx cost
-        gasPrice: useCustomFee.value ? customGasInWei.value : fee.value.div('21000')
+    onMounted(async () => {
+      if (isEth) {
+        const gasPrice = await getGasPrice();
+        const ethFee = BigNumber.from('21000').mul(gasPrice);
+        fee.value = ethFee;
+        // flooring this b/c the string we get back from formatUnits is a decimal
+        formattedCustomFee.value = Math.floor(formatUnits(gasPrice, 'gwei'));
+      } else {
+        fee.value = props.activeFee.fee;
       }
     });
 
+    // Define computed properties dependent on the fee (must be computed to react to ETH gas price updates by user).
+    // Variables prefixed with `formatted*` are inteded for display in the U)
+    const amountReceived = computed(() => amount.sub(useCustomFee.value ? customFeeInWei.value : fee.value)); // amount user will receive
+    const formattedFee = computed(() => round(formatUnits(fee.value, decimals), numDecimals)); // relayer fee, rounded
+    const formattedAmountReceived = computed(() => round(formatUnits(amountReceived.value, decimals), numDecimals)); // amount user will receive, rounded
+    // prevent withdraw attemps if fee is larger than amount
+    const canWithdraw = computed(() =>
+      BigNumber.from(amount).gt(useCustomFee.value ? customFeeInWei.value : fee.value)
+    );
+    const confirmationOptions = computed(() => {
+      if (!isEth) return {};
+      return {
+        // fee is the total cost in wei for the gas, so we divide by the tx cost
+        gasPrice: useCustomFee.value ? customGasInWei.value : fee.value.div('21000'),
+      };
+    });
 
     return {
       canWithdraw,

--- a/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
+++ b/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
@@ -181,7 +181,7 @@ export default defineComponent({
         const ethFee = BigNumber.from('21000').mul(gasPrice);
         fee.value = ethFee;
         // flooring this b/c the string we get back from formatUnits is a decimal
-        formattedCustomFee.value = Math.floor(formatUnits(gasPrice, 'gwei'));
+        formattedCustomFee.value = String(Math.floor(Number(formatUnits(gasPrice, 'gwei'))));
       } else {
         fee.value = props.activeFee.fee;
       }
@@ -200,7 +200,7 @@ export default defineComponent({
       if (!isEth) return {};
       return {
         // fee is the total cost in wei for the gas, so we divide by the tx cost
-        gasPrice: useCustomFee.value ? customGasInWei.value : fee.value.div('21000'),
+        gasPrice: useCustomFee.value ? customGasInWei.value : BigNumber.from(fee.value).div('21000'),
       };
     });
 

--- a/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
+++ b/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
@@ -17,14 +17,16 @@
       </div>
 
       <div>
-        <div v-if="isEth" class="text-caption text-grey q-mt-md">
-          {{ useCustomFee ? 'Custom' : '' }} Transaction Fee
-          <q-icon
+        <div v-if="isEth" class="text-caption text-grey q-mt-md row items-center">
+          <div>{{ useCustomFee ? 'Custom' : '' }} Transaction Fee</div>
+          <base-button
             v-if="useCustomFee"
             @click="toggleCustomFee"
-            color="primary"
-            class="cursor-pointer q-ml-xs"
-            name="fas fa-times"
+            class="q-ml-xs"
+            :dense="true"
+            :flat="true"
+            label="Cancel"
+            size="1em"
           />
         </div>
         <div v-else class="text-caption text-grey q-mt-md">Relayer Gas Fee</div>

--- a/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
+++ b/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
@@ -67,7 +67,7 @@
 
       <div v-if="!canWithdraw" class="border-warning q-mt-lg q-pa-md">
         <q-icon name="fas fa-exclamation-triangle" color="warning" left />
-        Cannot withdraw because fee is larger than amount
+        Cannot withdraw, please correct fee error
       </div>
     </q-card-section>
 
@@ -193,9 +193,10 @@ export default defineComponent({
     const formattedFee = computed(() => round(formatUnits(fee.value, decimals), numDecimals)); // relayer fee, rounded
     const formattedAmountReceived = computed(() => round(formatUnits(amountReceived.value, decimals), numDecimals)); // amount user will receive, rounded
     // prevent withdraw attemps if fee is larger than amount
-    const canWithdraw = computed(() =>
-      BigNumber.from(amount).gt(useCustomFee.value ? customFeeInWei.value : fee.value)
-    );
+    const canWithdraw = computed(() => {
+      const feeInWei = useCustomFee.value ? customFeeInWei.value : fee.value
+      return BigNumber.from(amount).gt(feeInWei) && BigNumber.from('0').lt(feeInWei)
+    });
     const confirmationOptions = computed(() => {
       if (!isEth) return {};
       return {

--- a/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
+++ b/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
@@ -31,7 +31,7 @@
         <div v-if="useCustomFee" class="row justify-start items-center">
           <div class="col-12 row items-center">
             <img :src="tokenURL" class="q-mr-sm" style="height: 1rem" />
-            <span class="text-danger">-{{ formattedCustomFeeEth }} {{ symbol }}</span>
+            <span>-{{ formattedCustomFeeEth }} {{ symbol }}</span>
           </div>
           <div class="col-12" :style="{ maxWidth: '200px' }">
             <base-input
@@ -47,7 +47,7 @@
         </div>
         <div v-else class="row justify-start items-center">
           <img :src="tokenURL" class="q-mr-sm" style="height: 1rem" />
-          <div class="text-danger">-{{ formattedFee }} {{ symbol }}</div>
+          <div>-{{ formattedFee }} {{ symbol }}</div>
           <div @click="toggleCustomFee" class="text-caption hyperlink">
             <q-icon name="fas fa-edit" color="primary" right />
           </div>

--- a/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
+++ b/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
@@ -28,6 +28,7 @@
               type="number"
               suffix="Gwei"
               :dense="true"
+              :lazyRules="false"
               :rules="isValidFeeAmount"
               >
             </base-input>

--- a/frontend/src/components/BaseButton.vue
+++ b/frontend/src/components/BaseButton.vue
@@ -13,6 +13,7 @@
       no-caps
       :outline="outline"
       :padding="padding"
+      :size="size"
       :text-color="textColor"
       :type="type"
       @click="handleClick"
@@ -82,6 +83,12 @@ export default defineComponent({
     },
 
     padding: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
+
+    size: {
       type: String,
       required: false,
       default: undefined,

--- a/frontend/src/components/BaseInput.vue
+++ b/frontend/src/components/BaseInput.vue
@@ -139,7 +139,7 @@ export default Vue.extend({
     },
 
     placeholder: {
-      type: String | Number,
+      type: undefined,
       required: false,
       default: undefined,
     },

--- a/frontend/src/components/BaseInput.vue
+++ b/frontend/src/components/BaseInput.vue
@@ -139,7 +139,7 @@ export default Vue.extend({
     },
 
     placeholder: {
-      type: String|Number,
+      type: String | Number,
       required: false,
       default: undefined,
     },

--- a/frontend/src/components/BaseInput.vue
+++ b/frontend/src/components/BaseInput.vue
@@ -17,6 +17,7 @@
     :rules="[(val) => rules(val)]"
     :suffix="suffix"
     :type="type"
+    :min="type === 'number' ? 0 : undefined"
     :outlined="outlined"
     :placeholder="placeholder"
     standout
@@ -138,7 +139,7 @@ export default Vue.extend({
     },
 
     placeholder: {
-      type: String,
+      type: String|Number,
       required: false,
       default: undefined,
     },

--- a/frontend/src/layouts/BaseLayout.vue
+++ b/frontend/src/layouts/BaseLayout.vue
@@ -52,7 +52,7 @@
 
             <!-- ADDRESS AND SETTINGS AND SETTINGS -->
             <div class="col-auto q-mr-md">
-              <div>
+              <div class="row">
                 <connect-wallet>
                   <span v-if="userDisplayAddress" class="text-caption cursor-pointer dark-toggle">
                     {{ userDisplayAddress }}

--- a/frontend/src/layouts/BaseLayout.vue
+++ b/frontend/src/layouts/BaseLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-layout view="hhh Lpr fff" style="z-index: 0;">
+  <q-layout view="hhh Lpr fff" style="z-index: 0">
     <q-header class="q-mx-md q-mt-md" style="color: #000000; background-color: rgba(0, 0, 0, 0)">
       <div class="column all-content-format">
         <!-- Main header -->

--- a/frontend/src/layouts/BaseLayout.vue
+++ b/frontend/src/layouts/BaseLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-layout view="hhh Lpr fff">
+  <q-layout view="hhh Lpr fff" style="z-index: 0;">
     <q-header class="q-mx-md q-mt-md" style="color: #000000; background-color: rgba(0, 0, 0, 0)">
       <div class="column all-content-format">
         <!-- Main header -->

--- a/frontend/src/pages/AccountSend.vue
+++ b/frontend/src/pages/AccountSend.vue
@@ -42,7 +42,8 @@
           :disable="isSending"
           :flat="true"
           :full-width="true"
-          label="Generate payment link"
+          icon="far fa-copy"
+          label="Copy payment link"
         />
       </div>
     </q-form>

--- a/frontend/src/pages/FAQ.vue
+++ b/frontend/src/pages/FAQ.vue
@@ -364,6 +364,21 @@
         </f-a-q-item>
       </div>
 
+      <div @click="copyUrl" id="what-are-payment-links">
+        <f-a-q-item :expanded="selectedId === 'what-are-payment-links'" question="What are the payment links?">
+          <p>
+            When on the Send page, fill out some or all of the Send form and click the
+            <span class="text-italic">Copy payment link</span> button. This will copy a URL to your clipboard that, when
+            visited, pre-populates the send form with the values in the URL.
+          </p>
+          <p>
+            Be careful when specifying an amount as part of your payment link, as it can reduce privacy. For example, if
+            you share a payment link so people can donate 100 DAI to you, and suddenly lots of 100 DAI sends start going
+            through Umbra, observers will know that it's very likely those transfers are to you.
+          </p>
+        </f-a-q-item>
+      </div>
+
       <!-- Receiving Funds -->
       <div class="separator q-mt-lg q-mb-xl"></div>
       <div

--- a/frontend/src/utils/alerts.ts
+++ b/frontend/src/utils/alerts.ts
@@ -15,6 +15,7 @@ const messagesToIgnore = [
   'Navigating to current location', // e.g. user clicks "Home" in nav bar when already on home page
   "Cannot read property 'validate' of null", // user navigates off Send page too quickly after sending, so "resetValidation()" fails
   'Document is not focused', // happens when user unfocuses DOM while app was trying to copy something to clipboard
+  'unknown account #0', // happens when we try to connect to a locked wallet
 ];
 
 /**

--- a/frontend/src/utils/ethers.ts
+++ b/frontend/src/utils/ethers.ts
@@ -5,13 +5,13 @@
  */
 
 export { getAddress } from '@ethersproject/address';
-export { BigNumber } from '@ethersproject/bignumber';
+export { BigNumberish, BigNumber } from '@ethersproject/bignumber';
 export { isHexString, joinSignature } from '@ethersproject/bytes';
 export { AddressZero, MaxUint256 } from '@ethersproject/constants';
 export { Contract } from '@ethersproject/contracts';
 export { namehash } from '@ethersproject/hash';
 export { keccak256 } from '@ethersproject/keccak256';
 export { Logger, LogLevel } from '@ethersproject/logger';
-export { Block, JsonRpcSigner, Network, TransactionReceipt, TransactionResponse, Web3Provider, } from '@ethersproject/providers'; // prettier-ignore
+export { Block, JsonRpcProvider, JsonRpcSigner, Network, TransactionReceipt, TransactionResponse, Web3Provider, } from '@ethersproject/providers'; // prettier-ignore
 export { toUtf8Bytes } from '@ethersproject/strings';
 export { parseUnits, formatUnits } from '@ethersproject/units';

--- a/frontend/src/utils/payment-links.ts
+++ b/frontend/src/utils/payment-links.ts
@@ -1,0 +1,92 @@
+import { copyToClipboard } from 'quasar';
+import { notifyUser } from 'src/utils/alerts';
+import { JsonRpcProvider } from 'src/utils/ethers';
+import useWalletStore from 'src/store/wallet';
+import { TokenInfo } from 'components/models';
+import { utils as umbraUtils } from '@umbra/umbra-js';
+import { ITXRelayer } from 'src/utils/relayer';
+
+/**
+ * @notice Returns a provider, falling back to a mainnet provider if user's wallet is not connected
+ */
+function getProvider() {
+  const { provider } = useWalletStore();
+  return provider.value || new JsonRpcProvider(`https://mainnet.infura.io/v3/${String(process.env.INFURA_ID)}`);
+}
+
+/**
+ * @notice Returns a list of supported tokens, falling back to the mainnet token list
+ */
+async function getTokens() {
+  // If we have a valid relayer instance and associated token list, return it
+  const { relayer, tokens } = useWalletStore();
+  if (relayer.value && tokens.value) return tokens.value;
+
+  // Otherwise, get the default list
+  const provider = getProvider();
+  const relayerInstance = await ITXRelayer.create(provider);
+
+  // Make sure ETH is on the list. It's ok if it's there twice because we use the first found instance when parsing links
+  const ethToken = { address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', name: 'Ether', decimals: 18, symbol: 'ETH', logoURI: '/tokens/eth.svg', chainId: 1 }; // prettier-ignore
+  return [...relayerInstance.tokens, ethToken];
+}
+
+/**
+ * @notice Generates a link that pre-fills the Send form. At least one field is required
+ * @dev Falls back to a mainnet provider if user's wallet is not connected
+ * @param to Recipient identifer, such as an ENS name
+ * @param token Token details
+ * @param amount Amount to send, as a human-readable number
+ */
+export async function generatePaymentLink({
+  to = undefined,
+  token = undefined,
+  amount = undefined,
+}: {
+  to: string | undefined;
+  token: TokenInfo | undefined;
+  amount: string | undefined;
+}) {
+  // Ensure at least one form field was provided
+  if (!to && !token && !amount) throw new Error('Please complete at least one field to generate a payment link');
+
+  // Verify the recipient ID is valid if provided (this throws if public keys could not be found)
+  if (to) await umbraUtils.lookupRecipient(to, getProvider());
+
+  // Generate payment link and copy to clipboard
+  const url = new URL(`${window.location.href}`);
+  if (to) url.searchParams.set('to', to);
+  if (token) url.searchParams.set('token', token.symbol);
+  if (amount) url.searchParams.set('amount', amount);
+
+  await copyToClipboard(url.toString());
+  notifyUser('positive', 'Payment link copied to clipboard');
+}
+
+/**
+ * @notice Parses a payment link based on the query parameters of the current page
+ */
+export async function parsePaymentLink() {
+  // Setup output object
+  const paymentData: { to: string | null; token: TokenInfo | null; amount: string | null } = {
+    to: null,
+    token: null,
+    amount: null,
+  };
+
+  // Parse query parameters
+  const params = new URLSearchParams(window.location.search);
+  for (const [key, value] of params) {
+    // For `to` and `amount`, assign them directly
+    if (key === 'to' || key === 'amount') {
+      paymentData[key] = value;
+      continue;
+    }
+
+    // Otherwise, parse the token symbol into it's TokenInfo object
+    const tokens = await getTokens(); // get list of supported tokens
+    paymentData['token'] = tokens.filter((token) => token.symbol.toLowerCase() === value.toLowerCase())[0];
+  }
+
+  return paymentData;
+}

--- a/frontend/src/utils/relayer.ts
+++ b/frontend/src/utils/relayer.ts
@@ -2,6 +2,7 @@
  * @notice Class for managing relayed withdrawal transactions
  */
 
+import { JsonRpcProvider } from 'src/utils/ethers';
 import {
   ConfirmedITXStatusResponse,
   FeeEstimateResponse,
@@ -16,7 +17,7 @@ import {
 export class ITXRelayer {
   constructor(readonly baseUrl: string, readonly tokens: TokenInfo[]) {}
 
-  static async create(provider: Provider) {
+  static async create(provider: Provider | JsonRpcProvider) {
     // Get API URL based on chain ID
     const chainId = (await provider.getNetwork()).chainId;
     const baseUrl = chainId === 1 ? 'https://mainnet.api.umbra.cash' : 'https://rinkeby.api.umbra.cash';

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -1,3 +1,8 @@
+import { BigNumber } from './ethers';
+
+/**
+ * @notice Generates the Etherscan URL based on the given `txHash` and `chainId`
+ */
 export const getEtherscanUrl = (txHash: string, chainId: number) => {
   let networkPrefix = ''; // assume mainnet by default
   if (chainId === 1) networkPrefix = '';
@@ -8,9 +13,47 @@ export const getEtherscanUrl = (txHash: string, chainId: number) => {
   return `https://${networkPrefix}etherscan.io/tx/${txHash}`;
 };
 
+/**
+ * @notice Rounds `value` to the specified number of `decimals` and returns a string
+ */
 export const round = (value: number | string, decimals = 2) => {
   return Number(value).toLocaleString(undefined, {
     minimumFractionDigits: 0,
     maximumFractionDigits: decimals,
   });
+};
+
+/**
+ * @notice GETs JSON from the provided `url`
+ */
+export const jsonFetch = (url: string) => fetch(url).then((res) => res.json());
+
+// Shape of data returned from the GasNow API
+type GasNowResponse = {
+  code: number; // status code, 200 for success
+  // Prices by speed are given in wei
+  data: {
+    rapid: number;
+    fast: number;
+    standard: number;
+    slow: number;
+    timestamp: number; // request timestamp
+  };
+};
+
+// Valid types for specifying speed
+type GasNowSpeed = keyof Omit<GasNowResponse['data'], 'timestamp'>;
+
+/**
+ * @notice Gets the current gas price via GasNow API
+ * @param gasPriceSpeed string of gas price speed from GasNow (e.g. 'rapid')
+ */
+export const getGasPrice = async (gasPriceSpeed: GasNowSpeed = 'rapid'): Promise<BigNumber> => {
+  try {
+    const response: GasNowResponse = await jsonFetch('https://www.gasnow.org/api/v3/gas/price');
+    const gasPriceInWei = response.data[gasPriceSpeed];
+    return BigNumber.from(gasPriceInWei);
+  } catch (e) {
+    throw new Error(`Error fetching gas price from GasNow API: ${e.message as string}`);
+  }
 };


### PR DESCRIPTION
Changes in this PR:

1. Lets user choose gas price when withdrawing ETH: The default gas price to use is queried from the node, and if the user wants to change it, they can. See #202 and #203 for more info / video demos

2. Adds payment links: On the send form, fill in any combination of fields and click the new "Generate Payment Link" button. This puts a URL on the clipboard that, when visited, pre-populates the form with the info in the link. It should work even if you visit the send page without a wallet connected

3. Prevents the "Unknown account #0" error when user rejects wallet connect prompt (resolves #192). More info in #205 

4. Fixes small UI error where modal is not on top of the page. More info in #205 

Thanks to @davidlaprade for helping with most of these!