### PR TITLE
Improve notifications

### DIFF
--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -407,7 +407,7 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
         const { gasPrice } = options;
         tx = await umbra.value.withdraw(spendingPrivateKey, token.address, acceptor, { gasPrice });
         txHashIfEth.value = tx.hash;
-        txNotify(tx.hash);
+        txNotify(tx.hash, provider.value);
         await tx.wait();
       } else {
         // Withdrawing token

--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -407,7 +407,7 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
         const { gasPrice } = options;
         tx = await umbra.value.withdraw(spendingPrivateKey, token.address, acceptor, { gasPrice });
         txHashIfEth.value = tx.hash;
-        txNotify(tx.hash, provider.value);
+        void txNotify(tx.hash, provider.value);
         await tx.wait();
       } else {
         // Withdrawing token

--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -245,7 +245,7 @@ function useAdvancedFeatures(spendingKeyPair: KeyPair) {
   // For advanced mode: copyies the provided stealth private key to the clipboard
   const copyPrivateKey = async (privateKey: string) => {
     await copyToClipboard(privateKey);
-    notifyUser('positive', 'Private key copied to clipboard');
+    notifyUser('success', 'Private key copied to clipboard');
     hidePrivateKey();
   };
 
@@ -336,7 +336,7 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
   async function copySenderAddress(row: UserAnnouncement) {
     // row.receipt.from has the truncated from address shown in the UI, so here we use the row.tx.from address
     await copyToClipboard(row.tx.from);
-    notifyUser('positive', 'Sender address copied to clipboard');
+    notifyUser('success', 'Sender address copied to clipboard');
   }
 
   /**

--- a/frontend/src/pages/AccountSend.vue
+++ b/frontend/src/pages/AccountSend.vue
@@ -59,13 +59,13 @@ import useSettingsStore from 'src/store/settings';
 import useWalletStore from 'src/store/wallet';
 import { txNotify } from 'src/utils/alerts';
 import { generatePaymentLink, parsePaymentLink } from 'src/utils/payment-links';
-import { TokenInfo } from 'components/models';
+import { Provider, TokenInfo } from 'components/models';
 import ERC20 from 'src/contracts/ERC20.json';
 import ConnectWallet from 'components/ConnectWallet.vue';
 
 function useSendForm() {
   const { advancedMode } = useSettingsStore();
-  const { tokens: tokenOptions, getTokenBalances, balances, umbra, signer, userAddress } = useWalletStore();
+  const { tokens: tokenOptions, getTokenBalances, balances, umbra, signer, provider, userAddress } = useWalletStore();
 
   // Helpers
   const sendFormRef = ref<QForm>();
@@ -140,14 +140,14 @@ function useSendForm() {
         // If insufficient allowance, get approval
         if (amount.gt(allowance)) {
           const approveTx = await tokenContract.approve(umbraAddress, MaxUint256);
-          txNotify(approveTx.hash);
+          void txNotify(approveTx.hash, provider.value as Provider);
           await approveTx.wait();
         }
       }
 
       // Send with Umbra
       const { tx } = await umbra.value.send(signer.value, tokenAddress, amount, recipientId.value);
-      txNotify(tx.hash);
+      void txNotify(tx.hash, provider.value as Provider);
       await tx.wait();
       resetForm();
     } finally {

--- a/frontend/src/pages/AccountSetup.vue
+++ b/frontend/src/pages/AccountSetup.vue
@@ -280,7 +280,7 @@ function useKeys() {
 
   async function getPrivateKeysHandler() {
     if (keyStatus.value === 'success') {
-      notifyUser('info', 'You have already signed. Please continue to the next step');
+      notifyUser('hint', 'You have already signed. Please continue to the next step');
       return;
     }
     try {

--- a/frontend/src/pages/FAQ.vue
+++ b/frontend/src/pages/FAQ.vue
@@ -1176,7 +1176,7 @@ function useScrollToElement(context: SetupContext) {
     const slug = context.root.$router.currentRoute.path; // includes the leading forward slash
     const page = `${slug}#${elementId}`;
     await copyToClipboard(`${window.location.origin}${page}`);
-    if (el.getAttribute('isHeader')) notifyUser('positive', 'URL successfully copied to clipboard');
+    if (el.getAttribute('isHeader')) notifyUser('success', 'URL successfully copied to clipboard');
     window.history.pushState('', '', page); // updates URL in navigation bar
   };
 

--- a/frontend/src/utils/ens.ts
+++ b/frontend/src/utils/ens.ts
@@ -152,13 +152,13 @@ export const setSubdomainKeys = async (
     viewingPubKeyX // compressed viewing public key without prefix
   )) as TransactionResponse;
   window.logger.debug('tx1.hash: ', tx1.hash);
-  txNotify(tx1.hash);
+  txNotify(tx1.hash, signer.provider as Provider);
 
   // Send second transaction to configure the reverse resolver
   const reverseRegistrar = getContract('ENSReverseRegistrar', provider).connect(signer);
   const tx2 = (await reverseRegistrar.setName(name)) as TransactionResponse;
   window.logger.debug('tx2.hash: ', tx2.hash);
-  txNotify(tx2.hash);
+  txNotify(tx2.hash, signer.provider as Provider);
 
   return [tx1, tx2];
 };
@@ -203,7 +203,7 @@ export const setRootNameKeys = async (
     window.logger.debug('publicResolver: ', publicResolver.address);
     const tx = (await publicResolver.setAuthorisation(node, fskResolverAddress, true)) as TransactionResponse;
     window.logger.debug('step 1 tx.hash: ', tx.hash);
-    txNotify(tx.hash);
+    txNotify(tx.hash, signer.provider as Provider);
     txs.push(tx);
 
     // Step 2: Change the user's resolver to the ForwardingStealthKeyResolver
@@ -212,7 +212,7 @@ export const setRootNameKeys = async (
     window.logger.debug('registry: ', registry.address);
     const tx2 = (await registry.setResolver(node, fskResolverAddress)) as TransactionResponse;
     window.logger.debug('step 2 tx2.hash: ', tx2.hash);
-    txNotify(tx2.hash);
+    txNotify(tx2.hash, signer.provider as Provider);
     txs.push(tx2);
     await tx2.wait(); // this needs to be mined before step 3, since step 3 reads your current resolver
   }
@@ -220,7 +220,7 @@ export const setRootNameKeys = async (
   // Step 3: Set the stealth keys on the appropriate resolver
   const tx = await domainService.setPublicKeys(name, spendingPublicKey, viewingPublicKey);
   window.logger.debug('step 3 tx.hash: ', tx.hash);
-  txNotify(tx.hash);
+  txNotify(tx.hash, signer.provider as Provider);
   txs.push(tx);
   window.logger.debug('txs: ', txs);
 

--- a/frontend/src/utils/ens.ts
+++ b/frontend/src/utils/ens.ts
@@ -152,13 +152,13 @@ export const setSubdomainKeys = async (
     viewingPubKeyX // compressed viewing public key without prefix
   )) as TransactionResponse;
   window.logger.debug('tx1.hash: ', tx1.hash);
-  txNotify(tx1.hash, signer.provider as Provider);
+  void txNotify(tx1.hash, signer.provider as Provider);
 
   // Send second transaction to configure the reverse resolver
   const reverseRegistrar = getContract('ENSReverseRegistrar', provider).connect(signer);
   const tx2 = (await reverseRegistrar.setName(name)) as TransactionResponse;
   window.logger.debug('tx2.hash: ', tx2.hash);
-  txNotify(tx2.hash, signer.provider as Provider);
+  void txNotify(tx2.hash, signer.provider as Provider);
 
   return [tx1, tx2];
 };
@@ -203,7 +203,7 @@ export const setRootNameKeys = async (
     window.logger.debug('publicResolver: ', publicResolver.address);
     const tx = (await publicResolver.setAuthorisation(node, fskResolverAddress, true)) as TransactionResponse;
     window.logger.debug('step 1 tx.hash: ', tx.hash);
-    txNotify(tx.hash, signer.provider as Provider);
+    void txNotify(tx.hash, signer.provider as Provider);
     txs.push(tx);
 
     // Step 2: Change the user's resolver to the ForwardingStealthKeyResolver
@@ -212,7 +212,7 @@ export const setRootNameKeys = async (
     window.logger.debug('registry: ', registry.address);
     const tx2 = (await registry.setResolver(node, fskResolverAddress)) as TransactionResponse;
     window.logger.debug('step 2 tx2.hash: ', tx2.hash);
-    txNotify(tx2.hash, signer.provider as Provider);
+    void txNotify(tx2.hash, signer.provider as Provider);
     txs.push(tx2);
     await tx2.wait(); // this needs to be mined before step 3, since step 3 reads your current resolver
   }
@@ -220,7 +220,7 @@ export const setRootNameKeys = async (
   // Step 3: Set the stealth keys on the appropriate resolver
   const tx = await domainService.setPublicKeys(name, spendingPublicKey, viewingPublicKey);
   window.logger.debug('step 3 tx.hash: ', tx.hash);
-  txNotify(tx.hash, signer.provider as Provider);
+  void txNotify(tx.hash, signer.provider as Provider);
   txs.push(tx);
   window.logger.debug('txs: ', txs);
 

--- a/frontend/src/utils/payment-links.ts
+++ b/frontend/src/utils/payment-links.ts
@@ -60,7 +60,7 @@ export async function generatePaymentLink({
   if (amount) url.searchParams.set('amount', amount);
 
   await copyToClipboard(url.toString());
-  notifyUser('positive', 'Payment link copied to clipboard');
+  notifyUser('success', 'Payment link copied to clipboard');
 }
 
 /**

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -5,12 +5,14 @@ import { BigNumber } from './ethers';
  */
 export const getEtherscanUrl = (txHash: string, chainId: number) => {
   let networkPrefix = ''; // assume mainnet by default
-  if (chainId === 1) networkPrefix = '';
-  if (chainId === 3) networkPrefix = 'ropsten.';
-  if (chainId === 4) networkPrefix = 'rinkeby.';
-  if (chainId === 5) networkPrefix = 'goerli.';
-  if (chainId === 42) networkPrefix = 'kovan.';
-  return `https://${networkPrefix}etherscan.io/tx/${txHash}`;
+  if (chainId === 1) networkPrefix = 'etherscan.io';
+  if (chainId === 3) networkPrefix = 'ropsten.etherscan.io';
+  if (chainId === 4) networkPrefix = 'rinkeby.etherscan.io';
+  if (chainId === 5) networkPrefix = 'goerli.etherscan.io';
+  if (chainId === 42) networkPrefix = 'kovan.etherscan.io';
+  if (chainId === 137) networkPrefix = 'polygonscan.com';
+  if (chainId === 80001) networkPrefix = 'mumbai.polygonscan.com';
+  return `https://${networkPrefix}/tx/${txHash}`;
 };
 
 /**

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -4,7 +4,7 @@ import { BigNumber } from './ethers';
  * @notice Generates the Etherscan URL based on the given `txHash` and `chainId`
  */
 export const getEtherscanUrl = (txHash: string, chainId: number) => {
-  let networkPrefix = ''; // assume mainnet by default
+  let networkPrefix = '';
   if (chainId === 1) networkPrefix = 'etherscan.io';
   if (chainId === 3) networkPrefix = 'ropsten.etherscan.io';
   if (chainId === 4) networkPrefix = 'rinkeby.etherscan.io';


### PR DESCRIPTION
Closes #213

I ended up sticking with Blocknative's notify.js because they have have a "UI Only" mode where you can control it manually like a generic notification library. I think their toasts look nice, they're likely familiar to many users, and it's a lot less work than building our own notification system, so using this seems like a great option.

As a result, there's two changes to this PR:
1. Transaction notifications: These use the same Blocknative notify.js library but now in "UI Only" mode. This looks and feels identical to users, and we handle the notification status manually based on the connected provider within the `txNotify` method. You can also click a notification and it will open the Etherscan link
2. Other notifications: All other notifications now use the same notify.js library, instead of the Quasar notify library, and have the same look and feel as transaction notifications.

To test:
1. Send any types of transaction you like to see the "pending" and "success" notifications
2. Reject a transaction to see the "error" notification
3. In Account Setup, sign the message, then go back a step and sign again to see a "hint" style notification