### PR TITLE
Prevent UI Blocking During Scanning and Show Progress Bar

### DIFF
--- a/frontend/src/boot/components.ts
+++ b/frontend/src/boot/components.ts
@@ -4,6 +4,7 @@ import BaseButton from 'components/BaseButton.vue';
 import BaseInput from 'components/BaseInput.vue';
 import BaseSelect from 'components/BaseSelect.vue';
 import LoadingSpinner from 'components/LoadingSpinner.vue';
+import ProgressIndicator from 'components/ProgressIndicator.vue';
 
 // more info on params: https://quasar.dev/quasar-cli/cli-documentation/boot-files#Anatomy-of-a-boot-file
 export default boot(({ Vue }) => {
@@ -11,4 +12,5 @@ export default boot(({ Vue }) => {
   Vue.component('base-input', BaseInput);
   Vue.component('base-select', BaseSelect);
   Vue.component('loading-spinner', LoadingSpinner);
+  Vue.component('progress-indicator', ProgressIndicator);
 });

--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -27,7 +27,7 @@
 
     <div v-if="isLoading" class="text-center">
       <loading-spinner />
-      <div class="text-center text-italic">Scanning for funds...</div>
+      <div class="text-center text-italic">Processing results...</div>
     </div>
 
     <!-- Received funds table -->

--- a/frontend/src/components/ProgressIndicator.vue
+++ b/frontend/src/components/ProgressIndicator.vue
@@ -1,0 +1,26 @@
+<template>
+  <q-circular-progress
+    show-value
+    class="text-primary q-mx-auto q-my-xl"
+    :value="percentage"
+    size="4rem"
+    color="primary"
+    track-color="grey-3"
+  >
+    {{ percentage }}%
+  </q-circular-progress>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api';
+
+export default defineComponent({
+  name: 'ProgressIndicator',
+  props: {
+    percentage: { type: Number, required: true },
+  },
+  setup(props) {
+    return { props };
+  },
+});
+</script>

--- a/frontend/src/pages/AccountReceive.vue
+++ b/frontend/src/pages/AccountReceive.vue
@@ -66,7 +66,7 @@
 
       <!-- Scanning in progress -->
       <div v-else-if="scanStatus === 'scanning'" class="text-center">
-        <loading-spinner />
+        <progress-indicator :percentage="scanPercentage" />
         <div class="text-center text-italic">Scanning for funds...</div>
         <div class="text-center text-italic q-mt-lg">
           This may take a couple of minutes depending on your connection and device. This is normal&mdash; please be
@@ -97,6 +97,7 @@ function useScan() {
   const { getPrivateKeys, umbra, spendingKeyPair, viewingKeyPair, hasKeys, userAddress } = useWallet();
   type ScanStatus = 'waiting' | 'fetching' | 'scanning' | 'complete';
   const scanStatus = ref<ScanStatus>('waiting');
+  const scanPercentage = ref<number>(0);
   const userAnnouncements = ref<UserAnnouncement[]>([]);
 
   // Start and end blocks for advanced mode settings
@@ -195,8 +196,7 @@ function useScan() {
       viewingPrivKey,
       allAnnouncements,
       (percent) => {
-        percent;
-        // TODO: use this to show a progress bar
+        scanPercentage.value = Math.floor(percent);
       },
       (filteredAnnouncements) => {
         userAnnouncements.value = filteredAnnouncements;
@@ -207,6 +207,7 @@ function useScan() {
 
   function resetState() {
     scanStatus.value = 'waiting';
+    scanPercentage.value = 0;
     startBlockLocal.value = undefined;
     endBlockLocal.value = undefined;
     scanPrivateKeyLocal.value = undefined;
@@ -227,6 +228,7 @@ function useScan() {
     needsSignature,
     scanPrivateKeyLocal,
     scanStatus,
+    scanPercentage,
     setFormStatus,
     setScanBlocks,
     settingsFormRef,

--- a/frontend/src/worker/worker.ts
+++ b/frontend/src/worker/worker.ts
@@ -26,7 +26,7 @@ export const filterUserAnnouncements = (
 
     if (index < announcements.length) {
       progress((100 * index) / announcements.length);
-      setTimeout(doChunk, 1);
+      setTimeout(doChunk, 0);
     } else {
       completion(userAnnouncements);
     }

--- a/frontend/src/worker/worker.ts
+++ b/frontend/src/worker/worker.ts
@@ -1,0 +1,36 @@
+import { AnnouncementDetail, UserAnnouncement, Umbra } from '@umbra/umbra-js';
+import { getAddress } from 'src/utils/ethers';
+
+export const filterUserAnnouncements = (
+  spendingPublicKey: string,
+  viewingPrivateKey: string,
+  announcements: AnnouncementDetail[],
+  progress: (percentage: number) => void,
+  completion: (userAnnouncements: UserAnnouncement[]) => void
+) => {
+  const userAnnouncements: UserAnnouncement[] = [];
+  let index = 0;
+  const chunk = 10;
+
+  const doChunk = () => {
+    for (let count = chunk; count > 0 && index < announcements.length; count--, index++) {
+      const ann = announcements[index];
+      const { amount, from, receiver, timestamp, token: tokenAddr, txHash } = ann;
+      const { isForUser, randomNumber } = Umbra.isAnnouncementForUser(spendingPublicKey, viewingPrivateKey, ann);
+      const token = getAddress(tokenAddr); // ensure checksummed address
+      const isWithdrawn = false; // we always assume not withdrawn and leave it to the caller to check
+      if (isForUser) {
+        userAnnouncements.push({ randomNumber, receiver, amount, token, from, txHash, timestamp, isWithdrawn });
+      }
+    }
+
+    if (index < announcements.length) {
+      progress((100 * index) / announcements.length);
+      setTimeout(doChunk, 1);
+    } else {
+      completion(userAnnouncements);
+    }
+  };
+
+  doChunk();
+};

--- a/umbra-js/src/classes/Umbra.ts
+++ b/umbra-js/src/classes/Umbra.ts
@@ -313,8 +313,8 @@ export class Umbra {
     // that window is defined first to avoid trying to use fetch in node environments
     if (typeof window !== 'undefined' && this.chainConfig.subgraphUrl) {
       try {
-        // Map the subgraph amount field from string to BigNumber
         const subgraphAnnouncements = await this.fetchAllAnnouncementsFromSubgraph(startBlock, endBlock);
+        // Map the subgraph amount field from string to BigNumber
         return subgraphAnnouncements.map((x) => ({ ...x, amount: BigNumber.from(x.amount) }));
       } catch (err) {
         return this.fetchAllAnnouncementFromLogs(startBlock, endBlock);
@@ -380,8 +380,8 @@ export class Umbra {
     startBlock: string | number,
     endBlock: string | number
   ): Promise<AnnouncementDetail[]> {
-    // Graph query failed, try requesting logs directly IF we are not on polygon. If we are on
-    // Polygon, there isn't much we can do, so for now just show a warning and return an empty array
+     // Fetching announcements from logs is not possible on Polygon because the network produces too
+     // many blocks too quickly. If this is attempted, we throw an error.
     if (this.chainConfig.chainId === 137) {
       throw new Error('Cannot fetch Announcements from logs on Polygon, please try again later');
     }

--- a/umbra-js/src/index.ts
+++ b/umbra-js/src/index.ts
@@ -6,5 +6,5 @@ import * as cns from './utils/cns';
 import * as ens from './utils/ens';
 import * as utils from './utils/utils';
 
-export { ChainConfig, SendOverrides, ScanOverrides, Announcement, UserAnnouncement } from './types';
+export { ChainConfig, SendOverrides, ScanOverrides, Announcement, AnnouncementDetail, UserAnnouncement } from './types';
 export { KeyPair, RandomNumber, Umbra, StealthKeyRegistry, ens, cns, utils };

--- a/umbra-js/src/types.ts
+++ b/umbra-js/src/types.ts
@@ -55,6 +55,19 @@ export interface Announcement {
   token: string;
 }
 
+// Type definition for Announcement event with extra data from the chain
+export interface AnnouncementDetail {
+  amount: BigNumber;
+  ciphertext: string;
+  pkx: string;
+  receiver: string;
+  token: string;
+  block: string;
+  from: string;
+  timestamp: string;
+  txHash: string;
+}
+
 // Modified announcement data received from subgraph queries
 export interface SubgraphAnnouncement {
   amount: string;

--- a/umbra-js/test/Umbra.test.ts
+++ b/umbra-js/test/Umbra.test.ts
@@ -121,7 +121,8 @@ describe('Umbra class', () => {
       const umbra3 = new Umbra(jsonRpcProvider, 4);
       expect(umbra3.chainConfig.umbraAddress).to.equal('0xFb2dc580Eed955B528407b4d36FfaFe3da685401');
       expect(umbra3.chainConfig.startBlock).to.equal(8505089);
-      expect(umbra3.chainConfig.subgraphUrl).to.equal('https://api.thegraph.com/subgraphs/name/scopelift/umbrarinkeby');
+      //expect(umbra3.chainConfig.subgraphUrl).to.equal('https://api.thegraph.com/subgraphs/name/scopelift/umbrarinkeby');
+      expect(umbra3.chainConfig.subgraphUrl).to.equal(false);
 
       // --- Mainnet ---
       const umbra4 = new Umbra(jsonRpcProvider, 1);


### PR DESCRIPTION
* Refactor umbra-js to separate fetching from scanning announcements
* Chunk the scanning work in the frontend to prevent the UI from locking
* Show a progress bar while scanning for better UX

One weird issue: the UI flashes back to showing the loading indicator briefly after scanning is completed, but it's not clear to me why that is.