### PR TITLE
bug: ensure form validation happens when values are present

### DIFF
--- a/frontend/src/pages/AccountSend.vue
+++ b/frontend/src/pages/AccountSend.vue
@@ -245,8 +245,14 @@ function useSendForm() {
         humanAmount.value = undefined;
       }
 
-      // Revalidates form on network change
-      if (useNormalPubKey !== prevUseNormalPubKey || isLoadingValue !== prevIsLoadingValue) {
+      // Revalidates form
+      if (
+        // on network change
+        useNormalPubKey !== prevUseNormalPubKey ||
+        isLoadingValue !== prevIsLoadingValue ||
+        // when both token and value are present
+        (tokenValue && humanAmountValue)
+      ) {
         void sendFormRef.value?.validate();
       }
       const validId = Boolean(recipientIdValue) && (await isValidId(recipientIdValue as string)) === true;


### PR DESCRIPTION
#### Description 

Updates condition when form validation happens to ensure validation run if both token value and amount are present/updated.

The issue here was the `isValidTokenAmount` is mapped to the token amount field and the error message wasn't getting triggered when the token name was being updated 

#### Demo

![Untitled](https://user-images.githubusercontent.com/5358146/149530295-b2abee28-8e52-48e5-908d-0e1ab49a74b2.gif)


#### Fixes
fixes https://github.com/ScopeLift/umbra-protocol/issues/265 
