### PR TITLE
Frontend tweaks to support WETH on Polygon

### DIFF
--- a/frontend/src/components/WithdrawForm.vue
+++ b/frontend/src/components/WithdrawForm.vue
@@ -27,7 +27,7 @@
         <div v-else-if="activeFee" class="text-caption">
           Estimated withdrawal fee:
           <span class="text-bold">
-            {{ round(formatUnits(activeFee.fee, activeFee.token.decimals)) }}
+            {{ roundTokenAmount(activeFee.fee, activeFee.token) }}
             {{ activeFee.token.symbol }}
           </span>
         </div>
@@ -68,7 +68,7 @@
 import { defineComponent, PropType, ref } from '@vue/composition-api';
 import { FeeEstimateResponse } from './models';
 import { formatUnits } from 'src/utils/ethers';
-import { round } from 'src/utils/utils';
+import { roundTokenAmount } from 'src/utils/utils';
 import useWalletStore from 'src/store/wallet';
 
 export default defineComponent({
@@ -107,7 +107,7 @@ export default defineComponent({
     const { NATIVE_TOKEN } = useWalletStore();
     const content = ref<string>(destinationAddress || '');
     const nativeTokenSymbol = NATIVE_TOKEN.value.symbol;
-    return { formatUnits, round, emit, content, nativeTokenSymbol };
+    return { formatUnits, roundTokenAmount, emit, content, nativeTokenSymbol };
   },
 });
 </script>

--- a/frontend/src/pages/AccountSend.vue
+++ b/frontend/src/pages/AccountSend.vue
@@ -296,8 +296,13 @@ function useSendForm() {
     const chainId = BigNumber.from(currentChain.value?.chainId).toNumber();
     // Polygon
     if (chainId === 137) {
-      if (isNativeToken(tokenAddress)) return 1.0;
-      else return 3; // stablecoin token minimum
+      if (isNativeToken(tokenAddress)) {
+        return 1.0;
+      } else if (tokenAddress === '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619') {
+        return 0.001; // weth token minimum
+      } else {
+        return 3; // stablecoin token minimum
+      }
     }
     // Mainnet, Rinkeby, and other networks have higher ETH and stablecoin minimums due to higher fees
     if (isNativeToken(tokenAddress)) return 0.01;

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -1,5 +1,5 @@
 import { supportedChains } from 'src/components/models';
-import { BigNumber, BigNumberish, hexValue, parseUnits } from './ethers';
+import { BigNumber, BigNumberish, hexValue, parseUnits, formatUnits } from './ethers';
 
 /**
  * @notice Generates the Etherscan URL based on the given `txHash` or `address and `chainId`
@@ -26,6 +26,22 @@ export const round = (value: number | string, decimals = 2) => {
     minimumFractionDigits: 0,
     maximumFractionDigits: decimals,
   });
+};
+
+/**
+ * @notice Rounds to appropriate human readable decimals for the token
+ * @dev This is very fragile and should be replace with something robust, i.e. something that walks
+ * value and rounds considering sig-figs or similar
+ */
+export const roundTokenAmount = (amount: BigNumberish, token: { decimals: number; address: string }): string => {
+  const formatted = formatUnits(amount, token.decimals);
+  // WETH on Polygon
+  const isWeth = token.address === '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619';
+  if (isWeth) {
+    return round(formatted, 6);
+  } else {
+    return round(formatted, 2);
+  }
 };
 
 /**


### PR DESCRIPTION
Makes updates to the frontend in preparation for supporting non-stablecoin
tokens on Polygon, notably WETH.

* Defines minimum amount for Polygon WETH as 0.001 on the send page
* Rounds WETH amounts, which can be well less than 0 on Polygon, to
  display 6 decimals when showing fees and received amounts

Note: before the backend update for WETH support is deployed, there should be no noticeable changes in the UI from this PR. This PR can and should be reviewed, merged, and deployed ahead of the rollout of WETH support on the backend to ensure it works seamlessly on the frontend immediately.