### PR TITLE
fix: auto detect gaslimit on withdraw

### DIFF
--- a/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
+++ b/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
@@ -106,7 +106,7 @@
 import { computed, defineComponent, onMounted, PropType, ref } from '@vue/composition-api';
 import { UserAnnouncement } from '@umbra/umbra-js';
 import { FeeEstimate } from 'components/models';
-import { formatAddress } from 'src/utils/address';
+import { formatAddress, toAddress } from 'src/utils/address';
 import { BigNumber, formatUnits } from 'src/utils/ethers';
 import { getEtherscanUrl, getGasPrice, round, roundTokenAmount } from 'src/utils/utils';
 import useWalletStore from 'src/store/wallet';
@@ -207,9 +207,8 @@ export default defineComponent({
 
     onMounted(async () => {
       if (isNativeToken) {
-
         gasLimit.value = (await provider.value?.estimateGas({
-          to: props.destinationAddress,
+          to: toAddress(props.destinationAddress, provider.value),
           from: props.activeAnnouncement.receiver,
           value: amount,
           gasPrice: 0,

--- a/umbra-js/src/classes/Umbra.ts
+++ b/umbra-js/src/classes/Umbra.ts
@@ -231,8 +231,23 @@ export class Umbra {
       // Withdraw ETH
       // Based on gas price, compute how much ETH to transfer to avoid dust
       const ethBalance = await this.provider.getBalance(stealthWallet.address); // stealthWallet.address is our stealthAddress
+
+      // Estimate gas limit if not provided
+      if (!overrides.gasLimit) {
+        try {
+          overrides.gasLimit = await this.provider.estimateGas({
+            to: destination,
+            from: stealthWallet.address,
+            value: ethBalance,
+            gasPrice: 0
+          });
+        } catch {
+          overrides.gasLimit = '21000';
+        }
+      }
+
       const gasPrice = BigNumber.from(overrides.gasPrice || (await this.provider.getGasPrice()));
-      const gasLimit = BigNumber.from(overrides.gasLimit || '21000');
+      const gasLimit = BigNumber.from(overrides.gasLimit);
       const txCost = gasPrice.mul(gasLimit);
       if (txCost.gt(ethBalance)) {
         throw new Error('Stealth address ETH balance is not enough to pay for withdrawal gas cost');


### PR DESCRIPTION
#### Description 

`withdrawal` function has been updated and when invoked
-  if `overrides.gasLimit` is passed ->  that value is used
-  else it will try to fetch the gasLimit via `estimateGas`
- and if any error occurs -> will default to `2100` 


#### Refs 

fixes : https://github.com/ScopeLift/umbra-protocol/issues/262


#### Testing 

- locally tested with debugger statements
- Additonally set the default gasLimit to 2500 and executed the withdraw -> and the gas limit was set to 21000 (by the estimateGas` function
https://polygonscan.com/tx/0x2c64a01853ad85e4e5df74d2a03bdbf8ffb269100c6cd5a05a8c46e873dac4db

