### PR TITLE
fix: fallback to node's gas price if API is down

### DIFF
--- a/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
+++ b/frontend/src/components/AccountReceiveTableWithdrawConfirmation.vue
@@ -194,9 +194,19 @@ export default defineComponent({
       round(formatUnits(customFeeInWei.value, decimals), ethDisplayDecimals)
     );
 
+    // Wrapper around getGasPrice which falls back to returning the node's gas price if getGasPrice fails
+    async function tryGetGasPrice() {
+      try {
+        return await getGasPrice();
+      } catch (e) {
+        console.warn(`Could not get gas price: ${JSON.stringify(e)}`);
+        return await provider.value?.getGasPrice();
+      }
+    }
+
     onMounted(async () => {
       if (isNativeToken) {
-        const gasPrice = network.value?.chainId === 1 ? await getGasPrice() : await provider.value?.getGasPrice(); // use blocknative on mainnet, the node elsewhere
+        const gasPrice = network.value?.chainId === 1 ? await tryGetGasPrice() : await provider.value?.getGasPrice(); // use blocknative on mainnet, the node elsewhere
         const ethFee = BigNumber.from('21000').mul(gasPrice as BigNumber);
         fee.value = ethFee;
         // flooring this b/c the string we get back from formatUnits is a decimal


### PR DESCRIPTION
Current behavior: If https://api.txprice.com/ is down (like it is right now), mainnet ETH withdrawals are blocked because the call to their API fails and we do not handle that error

New behavior: Catch the error and fallback to using a gas price provided by the node. @apbendi feel free to rename `tryGetGasPrice` to `safeGetGasPrice` or any other method name you prefer

If https://api.txprice.com/ is no longer down at the time of testing, you may need to manually force `getGasPrice()` to throw to confirm the behavior works as expected