### PR TITLE
Render ENS Avatars

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "bnc-notify": "^1.5.1",
     "bnc-onboard": "^1.13.0",
     "core-js": "^3.6.5",
-    "ethers": "^5.5.3",
+    "ethers": "5.5",
     "quasar": "^1.0.0"
   },
   "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "bnc-notify": "^1.5.1",
     "bnc-onboard": "^1.13.0",
     "core-js": "^3.6.5",
-    "ethers": "5.5",
+    "ethers": "^5.5.3",
     "quasar": "^1.0.0"
   },
   "devDependencies": {

--- a/frontend/src/components/Avatar.vue
+++ b/frontend/src/components/Avatar.vue
@@ -1,0 +1,17 @@
+<template>
+  <img :src="avatar" id="avatar" width='20px' style='border-radius: 50%' />
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from '@vue/composition-api';
+
+export default defineComponent({
+  name: 'Avatar',
+  props: {
+    avatar: {
+      type: (null as unknown) as PropType<string | null>,
+      required: true,
+    },
+  },
+});
+</script>

--- a/frontend/src/components/Avatar.vue
+++ b/frontend/src/components/Avatar.vue
@@ -1,15 +1,22 @@
 <template>
-  <img :src="avatar" id="avatar" width='20px' style='border-radius: 50%' />
+  <img v-if="avatar" :src="avatar" id="avatar" width='20px' style='border-radius: 50%' />
+  <Jazzicon v-else :address="address" />
 </template>
 
 <script lang="ts">
 import { defineComponent, PropType } from '@vue/composition-api';
+import Jazzicon from 'src/components/Jazzicon.vue';
 
 export default defineComponent({
   name: 'Avatar',
+  components: { Jazzicon },
   props: {
     avatar: {
       type: (null as unknown) as PropType<string | null>,
+      required: false,
+    },
+    address: {
+      type: String,
       required: true,
     },
   },

--- a/frontend/src/components/Avatar.vue
+++ b/frontend/src/components/Avatar.vue
@@ -1,6 +1,7 @@
 <template>
-  <img v-if="avatar" :src="avatar" id="avatar" width='20px' style='border-radius: 50%' />
-  <Jazzicon v-else :address="address" />
+  <span id="avatar-container">
+    <Jazzicon :address="address" />
+  </span>
 </template>
 
 <script lang="ts">
@@ -20,5 +21,23 @@ export default defineComponent({
       required: true,
     },
   },
+  setup: (props) => {
+    if (props.avatar) {
+      // load the avatar image async and display the jazzicon while waiting
+      const avatarImg = new Image();
+      avatarImg.onload = () => {
+        document.querySelector('#jazzicon')?.remove();
+        document.querySelector('#avatar-container')?.appendChild(avatarImg);
+      }
+      avatarImg.id = 'avatar';
+      avatarImg.width = '20';
+      avatarImg.src = props.avatar;
+    }
+  },
 });
 </script>
+
+<style lang="sass">
+#avatar
+  border-radius: 50%
+</style>

--- a/frontend/src/components/Jazzicon.vue
+++ b/frontend/src/components/Jazzicon.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex" id="icon" />
+  <div class="flex" id="jazzicon" />
 </template>
 
 <script lang="ts">
@@ -15,7 +15,7 @@ export default defineComponent({
     onMounted(() => {
       const width = 20;
       const identicon = jazzicon(width, parseInt(props.address.slice(2, 10), 16));
-      document.querySelector('#icon')?.appendChild(identicon);
+      document.querySelector('#jazzicon')?.appendChild(identicon);
     });
   },
 });

--- a/frontend/src/layouts/AddressSettings.vue
+++ b/frontend/src/layouts/AddressSettings.vue
@@ -8,22 +8,30 @@
         <span v-if="userDisplayName">
           {{ userDisplayName }}
         </span>
-        <Jazzicon v-if="userAddress" :address="userAddress" class="q-ml-sm" />
+        <span v-if="userAddress">
+          <Avatar v-if="avatar" :avatar="avatar" class="q-ml-sm" />
+          <Jazzicon v-else :address="userAddress" class="q-ml-sm" />
+        </span>
       </div>
     </connect-wallet>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api';
+import { defineComponent, PropType } from '@vue/composition-api';
 import BaseTooltip from 'src/components/BaseTooltip.vue';
 import ConnectWallet from 'components/ConnectWallet.vue';
 import Jazzicon from 'src/components/Jazzicon.vue';
+import Avatar from 'src/components/Avatar.vue';
 
 export default defineComponent({
   name: 'AddressSettings',
-  components: { BaseTooltip, ConnectWallet, Jazzicon },
+  components: { BaseTooltip, ConnectWallet, Jazzicon, Avatar },
   props: {
+    avatar: {
+      type: (null as unknown) as PropType<string | null>,
+      required: true,
+    },
     userDisplayName: {
       type: String,
       required: true,

--- a/frontend/src/layouts/AddressSettings.vue
+++ b/frontend/src/layouts/AddressSettings.vue
@@ -8,10 +8,7 @@
         <span v-if="userDisplayName">
           {{ userDisplayName }}
         </span>
-        <span v-if="userAddress">
-          <Avatar v-if="avatar" :avatar="avatar" class="q-ml-sm" />
-          <Jazzicon v-else :address="userAddress" class="q-ml-sm" />
-        </span>
+        <Avatar v-if="userAddress" :address="userAddress" :avatar="avatar" class="q-ml-sm" />
       </div>
     </connect-wallet>
   </div>
@@ -21,12 +18,11 @@
 import { defineComponent, PropType } from '@vue/composition-api';
 import BaseTooltip from 'src/components/BaseTooltip.vue';
 import ConnectWallet from 'components/ConnectWallet.vue';
-import Jazzicon from 'src/components/Jazzicon.vue';
 import Avatar from 'src/components/Avatar.vue';
 
 export default defineComponent({
   name: 'AddressSettings',
-  components: { BaseTooltip, ConnectWallet, Jazzicon, Avatar },
+  components: { BaseTooltip, ConnectWallet, Avatar },
   props: {
     avatar: {
       type: (null as unknown) as PropType<string | null>,

--- a/frontend/src/layouts/BaseLayout.vue
+++ b/frontend/src/layouts/BaseLayout.vue
@@ -59,6 +59,7 @@
             <div v-else-if="!isLoading && (userDisplayName || network)" class="row justify-end items-center no-wrap">
               <div class="q-mr-md">
                 <address-settings
+                  :avatar="avatar"
                   :userAddress="userAddress"
                   :userDisplayName="userDisplayName"
                   :advancedMode="advancedMode"
@@ -236,10 +237,20 @@ export default defineComponent({
   components: { AddressSettings, ArgentWarningModal, BaseButton, BaseTooltip, ConnectWallet, HeaderLinks, NetworkDropdown }, // prettier-ignore
   setup() {
     const { advancedMode, isDark, toggleAdvancedMode, toggleDarkMode } = useSettingsStore();
-    const { isAccountSetup, isAccountSetupLegacy, isArgent, isLoading, network, userAddress, userDisplayName } = useWalletStore(); // prettier-ignore
+    const {
+      avatar,
+      isAccountSetup,
+      isAccountSetupLegacy,
+      isArgent,
+      isLoading,
+      network,
+      userAddress,
+      userDisplayName
+    } = useWalletStore();
     const argentModalDismissed = ref(false);
     const showArgentModal = computed(() => isArgent.value && !argentModalDismissed.value);
     return {
+      avatar,
       advancedMode,
       argentModalDismissed,
       drawerRight: ref(false),

--- a/frontend/src/store/wallet.ts
+++ b/frontend/src/store/wallet.ts
@@ -245,21 +245,7 @@ export default function useWalletStore() {
       const _isAccountSetup = _stealthKeys !== null;
 
       if (typeof _userEns === 'string') { // ENS address must exist
-        const chainId = provider.value.network.chainId;
-        switch (chainId) {
-          case 1: // mainnet
-          case 137: // polygon mainnet
-            avatar.value = await MAINNET_PROVIDER.getAvatar(_userEns);
-            break;
-          case 4: // rinkeby
-            const currentNetworkAvatar = await provider.value.getAvatar(_userEns);
-            const mainnetAvatar= await MAINNET_PROVIDER.getAvatar(_userEns);
-            // prefer the avatar on the current chain, if one exists
-            avatar.value = currentNetworkAvatar || mainnetAvatar;
-            break;
-          default:
-            console.log(`unhandled network ${chainId} for ENS avatars`);
-        }
+        avatar.value = await MAINNET_PROVIDER.getAvatar(_userEns);
       }
 
       // Check if user has legacy keys setup with their ENS or CNS names (if so, we hide Account Setup)

--- a/frontend/src/store/wallet.ts
+++ b/frontend/src/store/wallet.ts
@@ -244,15 +244,21 @@ export default function useWalletStore() {
       ]);
       const _isAccountSetup = _stealthKeys !== null;
 
-      if (typeof _userEns === 'string') {
-        // can only look up an avatar if there is an ENS address
-        if (provider.value.network.chainId === 1) {
-          avatar.value = await provider.value.getAvatar(_userEns);
-        } else {
-          const currentNetworkAvatar = await provider.value.getAvatar(_userEns);
-          const mainnetAvatar= await MAINNET_PROVIDER.getAvatar(_userEns);
-          // prefer the avatar on the current chain, if one exists
-          avatar.value = currentNetworkAvatar || mainnetAvatar;
+      if (typeof _userEns === 'string') { // ENS address must exist
+        const chainId = provider.value.network.chainId;
+        switch (chainId) {
+          case 1: // mainnet
+          case 137: // polygon mainnet
+            avatar.value = await MAINNET_PROVIDER.getAvatar(_userEns);
+            break;
+          case 4: // rinkeby
+            const currentNetworkAvatar = await provider.value.getAvatar(_userEns);
+            const mainnetAvatar= await MAINNET_PROVIDER.getAvatar(_userEns);
+            // prefer the avatar on the current chain, if one exists
+            avatar.value = currentNetworkAvatar || mainnetAvatar;
+            break;
+          default:
+            console.log(`unhandled network ${chainId} for ENS avatars`);
         }
       }
 

--- a/frontend/src/store/wallet.ts
+++ b/frontend/src/store/wallet.ts
@@ -44,6 +44,7 @@ const isAccountSetup = ref(false); // true if user has registered their address 
 const onboard = ref<OnboardAPI>(); // blocknative's onboard.js instafnce
 const isArgent = ref<boolean>(false); // true if user connected an argent wallet
 const stealthKeys = ref<{ spendingPublicKey: string; viewingPublicKey: string } | null>();
+const avatar = ref<string | null>('');
 
 // ========================================== Main Store ===========================================
 export default function useWalletStore() {
@@ -243,6 +244,18 @@ export default function useWalletStore() {
       ]);
       const _isAccountSetup = _stealthKeys !== null;
 
+      if (typeof _userEns === 'string') {
+        // can only look up an avatar if there is an ENS address
+        if (provider.value.network.chainId === 1) {
+          avatar.value = await provider.value.getAvatar(_userEns);
+        } else {
+          const currentNetworkAvatar = await provider.value.getAvatar(_userEns);
+          const mainnetAvatar= await MAINNET_PROVIDER.getAvatar(_userEns);
+          // prefer the avatar on the current chain, if one exists
+          avatar.value = currentNetworkAvatar || mainnetAvatar;
+        }
+      }
+
       // Check if user has legacy keys setup with their ENS or CNS names (if so, we hide Account Setup)
       const [_hasEnsKeys, _hasCnsKeys] = _isAccountSetup
         ? [false, false]
@@ -427,6 +440,7 @@ export default function useWalletStore() {
     isLoading: computed(() => isLoading.value),
     isArgent: computed(() => isArgent.value),
     provider: computed(() => provider.value),
+    avatar: computed(() => avatar.value),
     relayer: computed(() => relayer.value),
     signer: computed(() => signer.value),
     spendingKeyPair: computed(() => spendingKeyPair.value),

--- a/yarn.lock
+++ b/yarn.lock
@@ -22480,20 +22480,10 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-y18n@^3.2.1:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.2.tgz#85c901bd6470ce71fc4bb723ad209b70f7f28696"
-  integrity sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==
-
-y18n@^4.0.0:
+y18n@^3.2.1, y18n@^4.0.0, y18n@^4.0.1, y18n@^5.0.5:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
-
-y18n@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
-  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yaeti@^0.0.6:
   version "0.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1881,6 +1881,31 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/providers@5.5.3":
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.5.3.tgz#56c2b070542ac44eb5de2ed3cf6784acd60a3130"
+  integrity sha512-ZHXxXXXWHuwCQKrgdpIkbzMNJMvs+9YWemanwp1fA7XZEv7QlilseysPvQe0D7Q7DlkJX/w/bGA1MdgK2TbGvA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.5.0"
+    "@ethersproject/abstract-signer" "^5.5.0"
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/basex" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/hash" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/networks" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/random" "^5.5.0"
+    "@ethersproject/rlp" "^5.5.0"
+    "@ethersproject/sha2" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+    "@ethersproject/transactions" "^5.5.0"
+    "@ethersproject/web" "^5.5.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
 "@ethersproject/random@5.1.0", "@ethersproject/random@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.1.0.tgz#0bdff2554df03ebc5f75689614f2d58ea0d9a71f"
@@ -10186,6 +10211,42 @@ ethers@4.0.47:
     setimmediate "1.0.4"
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
+
+ethers@5.5:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.5.4.tgz#e1155b73376a2f5da448e4a33351b57a885f4352"
+  integrity sha512-N9IAXsF8iKhgHIC6pquzRgPBJEzc9auw3JoRkaKe+y4Wl/LFBtDDunNe7YmdomontECAcC5APaAgWZBiu1kirw==
+  dependencies:
+    "@ethersproject/abi" "5.5.0"
+    "@ethersproject/abstract-provider" "5.5.1"
+    "@ethersproject/abstract-signer" "5.5.0"
+    "@ethersproject/address" "5.5.0"
+    "@ethersproject/base64" "5.5.0"
+    "@ethersproject/basex" "5.5.0"
+    "@ethersproject/bignumber" "5.5.0"
+    "@ethersproject/bytes" "5.5.0"
+    "@ethersproject/constants" "5.5.0"
+    "@ethersproject/contracts" "5.5.0"
+    "@ethersproject/hash" "5.5.0"
+    "@ethersproject/hdnode" "5.5.0"
+    "@ethersproject/json-wallets" "5.5.0"
+    "@ethersproject/keccak256" "5.5.0"
+    "@ethersproject/logger" "5.5.0"
+    "@ethersproject/networks" "5.5.2"
+    "@ethersproject/pbkdf2" "5.5.0"
+    "@ethersproject/properties" "5.5.0"
+    "@ethersproject/providers" "5.5.3"
+    "@ethersproject/random" "5.5.1"
+    "@ethersproject/rlp" "5.5.0"
+    "@ethersproject/sha2" "5.5.0"
+    "@ethersproject/signing-key" "5.5.0"
+    "@ethersproject/solidity" "5.5.0"
+    "@ethersproject/strings" "5.5.0"
+    "@ethersproject/transactions" "5.5.0"
+    "@ethersproject/units" "5.5.0"
+    "@ethersproject/wallet" "5.5.0"
+    "@ethersproject/web" "5.5.1"
+    "@ethersproject/wordlists" "5.5.0"
 
 ethers@^4.0.0-beta.1, ethers@^4.0.32, ethers@^4.0.40:
   version "4.0.48"
@@ -22419,10 +22480,20 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-y18n@^3.2.1, y18n@^4.0.0, y18n@^4.0.1, y18n@^5.0.5:
+y18n@^3.2.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.2.tgz#85c901bd6470ce71fc4bb723ad209b70f7f28696"
+  integrity sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==
+
+y18n@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yaeti@^0.0.6:
   version "0.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22419,20 +22419,10 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-y18n@^3.2.1:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.2.tgz#85c901bd6470ce71fc4bb723ad209b70f7f28696"
-  integrity sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==
-
-y18n@^4.0.0:
+y18n@^3.2.1, y18n@^4.0.0, y18n@^4.0.1, y18n@^5.0.5:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
-
-y18n@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
-  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yaeti@^0.0.6:
   version "0.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1856,31 +1856,6 @@
     bech32 "1.1.4"
     ws "7.2.3"
 
-"@ethersproject/providers@5.5.2":
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.5.2.tgz#131ccf52dc17afd0ab69ed444b8c0e3a27297d99"
-  integrity sha512-hkbx7x/MKcRjyrO4StKXCzCpWer6s97xnm34xkfPiarhtEUVAN4TBBpamM+z66WcTt7H5B53YwbRj1n7i8pZoQ==
-  dependencies:
-    "@ethersproject/abstract-provider" "^5.5.0"
-    "@ethersproject/abstract-signer" "^5.5.0"
-    "@ethersproject/address" "^5.5.0"
-    "@ethersproject/basex" "^5.5.0"
-    "@ethersproject/bignumber" "^5.5.0"
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/constants" "^5.5.0"
-    "@ethersproject/hash" "^5.5.0"
-    "@ethersproject/logger" "^5.5.0"
-    "@ethersproject/networks" "^5.5.0"
-    "@ethersproject/properties" "^5.5.0"
-    "@ethersproject/random" "^5.5.0"
-    "@ethersproject/rlp" "^5.5.0"
-    "@ethersproject/sha2" "^5.5.0"
-    "@ethersproject/strings" "^5.5.0"
-    "@ethersproject/transactions" "^5.5.0"
-    "@ethersproject/web" "^5.5.0"
-    bech32 "1.1.4"
-    ws "7.4.6"
-
 "@ethersproject/providers@5.5.3":
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.5.3.tgz#56c2b070542ac44eb5de2ed3cf6784acd60a3130"
@@ -10212,42 +10187,6 @@ ethers@4.0.47:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@5.5:
-  version "5.5.4"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.5.4.tgz#e1155b73376a2f5da448e4a33351b57a885f4352"
-  integrity sha512-N9IAXsF8iKhgHIC6pquzRgPBJEzc9auw3JoRkaKe+y4Wl/LFBtDDunNe7YmdomontECAcC5APaAgWZBiu1kirw==
-  dependencies:
-    "@ethersproject/abi" "5.5.0"
-    "@ethersproject/abstract-provider" "5.5.1"
-    "@ethersproject/abstract-signer" "5.5.0"
-    "@ethersproject/address" "5.5.0"
-    "@ethersproject/base64" "5.5.0"
-    "@ethersproject/basex" "5.5.0"
-    "@ethersproject/bignumber" "5.5.0"
-    "@ethersproject/bytes" "5.5.0"
-    "@ethersproject/constants" "5.5.0"
-    "@ethersproject/contracts" "5.5.0"
-    "@ethersproject/hash" "5.5.0"
-    "@ethersproject/hdnode" "5.5.0"
-    "@ethersproject/json-wallets" "5.5.0"
-    "@ethersproject/keccak256" "5.5.0"
-    "@ethersproject/logger" "5.5.0"
-    "@ethersproject/networks" "5.5.2"
-    "@ethersproject/pbkdf2" "5.5.0"
-    "@ethersproject/properties" "5.5.0"
-    "@ethersproject/providers" "5.5.3"
-    "@ethersproject/random" "5.5.1"
-    "@ethersproject/rlp" "5.5.0"
-    "@ethersproject/sha2" "5.5.0"
-    "@ethersproject/signing-key" "5.5.0"
-    "@ethersproject/solidity" "5.5.0"
-    "@ethersproject/strings" "5.5.0"
-    "@ethersproject/transactions" "5.5.0"
-    "@ethersproject/units" "5.5.0"
-    "@ethersproject/wallet" "5.5.0"
-    "@ethersproject/web" "5.5.1"
-    "@ethersproject/wordlists" "5.5.0"
-
 ethers@^4.0.0-beta.1, ethers@^4.0.32, ethers@^4.0.40:
   version "4.0.48"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.48.tgz#330c65b8133e112b0613156e57e92d9009d8fbbe"
@@ -10300,9 +10239,9 @@ ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.2:
     "@ethersproject/wordlists" "5.1.0"
 
 ethers@^5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.5.3.tgz#1e361516711c0c3244b6210e7e3ecabf0c75fca0"
-  integrity sha512-fTT4WT8/hTe/BLwRUtl7I5zlpF3XC3P/Xwqxc5AIP2HGlH15qpmjs0Ou78az93b1rLITzXLFxoNX63B8ZbUd7g==
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.5.4.tgz#e1155b73376a2f5da448e4a33351b57a885f4352"
+  integrity sha512-N9IAXsF8iKhgHIC6pquzRgPBJEzc9auw3JoRkaKe+y4Wl/LFBtDDunNe7YmdomontECAcC5APaAgWZBiu1kirw==
   dependencies:
     "@ethersproject/abi" "5.5.0"
     "@ethersproject/abstract-provider" "5.5.1"
@@ -10322,7 +10261,7 @@ ethers@^5.5.3:
     "@ethersproject/networks" "5.5.2"
     "@ethersproject/pbkdf2" "5.5.0"
     "@ethersproject/properties" "5.5.0"
-    "@ethersproject/providers" "5.5.2"
+    "@ethersproject/providers" "5.5.3"
     "@ethersproject/random" "5.5.1"
     "@ethersproject/rlp" "5.5.0"
     "@ethersproject/sha2" "5.5.0"
@@ -22480,10 +22419,20 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-y18n@^3.2.1, y18n@^4.0.0, y18n@^4.0.1, y18n@^5.0.5:
+y18n@^3.2.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.2.tgz#85c901bd6470ce71fc4bb723ad209b70f7f28696"
+  integrity sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==
+
+y18n@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yaeti@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
Fixes #248 

When there is an [ENS avatar](https://app.ens.domains/name/nick.eth/details) associated with the wallet:

![image](https://user-images.githubusercontent.com/7997618/154820278-11637af0-7ef7-4777-afb3-0024d764f00b.png)

When there isn't an ENS avatar, we fall back to the jazzicon:

![image](https://user-images.githubusercontent.com/7997618/154820627-268a1796-6969-445e-9928-55eca326492c.png)

When we're on a chain that ENS isn't on, e.g. Polygon, we fallback to whatever avatar is on mainnet (if any):

![image](https://user-images.githubusercontent.com/7997618/154822567-06aff3b4-ad05-462e-9d46-a38313954e33.png)



