### PR TITLE
Fix/private key access

### DIFF
--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -472,7 +472,12 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
     if (!provider.value) throw new Error('Wallet not connected. Try refreshing the page and connect your wallet');
     if (!userAddress.value) throw new Error('Wallet not connected. Try refreshing the page and connect your wallet');
     activeAnnouncement.value = announcement;
-    const { safe, reasons } = await isAddressSafe(destinationAddress.value, userAddress.value, provider.value);
+    const { safe, reasons } = await isAddressSafe(
+      destinationAddress.value,
+      userAddress.value,
+      announcement.receiver,
+      provider.value
+    );
 
     if (safe) {
       showConfirmationModal.value = true;

--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -119,7 +119,15 @@
               </q-card-section>
               <q-separator />
               <q-card-actions class="row justify-center items-center">
-                <div v-if="props.row.isWithdrawn" class="text-positive">
+                <div
+                  v-if="props.row.isWithdrawn"
+                  class="text-positive"
+                  :class="{ 'cursor-pointer': advancedMode }"
+                  @click="
+                    hidePrivateKey();
+                    if (advancedMode) expanded = expanded[0] === props.key ? [] : [props.key];
+                  "
+                >
                   Withdrawn<q-icon name="fas fa-check" class="q-ml-sm" />
                 </div>
                 <base-button
@@ -144,6 +152,7 @@
                     @copyPrivateKey="copyPrivateKey(spendingPrivateKey)"
                     @updateDestinationAddress="destinationAddress = arguments[0]"
                     :destinationAddress="destinationAddress"
+                    :isWithdrawn="props.row.isWithdrawn"
                     :isWithdrawInProgress="isWithdrawInProgress"
                     :isFeeLoading="isFeeLoading"
                     :isNativeToken="isNativeToken(props.row.token)"
@@ -230,7 +239,7 @@
               <div v-else>{{ col.value }}</div>
             </q-td>
 
-            <!-- Expansion button, works accordian-style -->
+            <!-- Expansion button, works accordion-style -->
             <!--
             The click modifier is a bit clunky because it touches state in two independent composition functions,
              so we explain the two things it does here:
@@ -243,7 +252,15 @@
                  only one row is every expanded at a time
           -->
             <q-td auto-width>
-              <div v-if="props.row.isWithdrawn" class="text-positive">
+              <div
+                v-if="props.row.isWithdrawn"
+                class="text-positive"
+                :class="{ 'cursor-pointer': advancedMode }"
+                @click="
+                  hidePrivateKey();
+                  if (advancedMode) expanded = expanded[0] === props.key ? [] : [props.key];
+                "
+              >
                 Withdrawn<q-icon name="fas fa-check" class="q-ml-sm" />
               </div>
               <base-button
@@ -271,6 +288,7 @@
                 @copyPrivateKey="copyPrivateKey(spendingPrivateKey)"
                 @updateDestinationAddress="destinationAddress = arguments[0]"
                 :destinationAddress="destinationAddress"
+                :isWithdrawn="props.row.isWithdrawn"
                 :isWithdrawInProgress="isWithdrawInProgress"
                 :isFeeLoading="isFeeLoading"
                 :isNativeToken="isNativeToken(props.row.token)"

--- a/frontend/src/components/WithdrawForm.vue
+++ b/frontend/src/components/WithdrawForm.vue
@@ -1,55 +1,57 @@
 <template>
   <q-form @submit="emit('initializeWithdraw')" class="form-wide q-pa-md" style="white-space: normal">
     <!-- Withdrawal form -->
-    <div v-if="!isWithdrawInProgress">
-      <div>Enter address to withdraw funds to</div>
-      <base-input
-        v-model="content"
-        @input="emit('updateDestinationAddress', content)"
-        @click="emit('initializeWithdraw')"
-        appendButtonLabel="Withdraw"
-        :appendButtonDisable="isWithdrawInProgress || isFeeLoading"
-        :appendButtonLoading="isWithdrawInProgress"
-        :disable="isWithdrawInProgress"
-        label="Address"
-        lazy-rules
-        :rules="(val) => (val && val.length > 4) || 'Please enter valid address'"
-      />
-      <!-- Fee estimate -->
-      <div class="q-mb-lg">
-        <div v-if="!isNativeToken && isFeeLoading" class="text-caption text-italic">
-          <q-spinner-puff class="q-my-none q-mr-sm" color="primary" size="2rem" />
-          Fetching fee estimate...
-        </div>
-        <div v-else-if="isNativeToken" class="text-caption">
-          Withdrawal fee: <span class="text-bold"> 0 {{ nativeTokenSymbol }} </span>
-        </div>
-        <div v-else-if="activeFee" class="text-caption">
-          Estimated withdrawal fee:
-          <span class="text-bold">
-            {{ humanizeTokenAmount(activeFee.fee, activeFee.token) }}
-            {{ activeFee.token.symbol }}
-          </span>
+    <div v-if="!isWithdrawn" class="q-mb-lg">
+      <div v-if="!isWithdrawInProgress">
+        <div>Enter address to withdraw funds to</div>
+        <base-input
+          v-model="content"
+          @input="emit('updateDestinationAddress', content)"
+          @click="emit('initializeWithdraw')"
+          appendButtonLabel="Withdraw"
+          :appendButtonDisable="isWithdrawInProgress || isFeeLoading"
+          :appendButtonLoading="isWithdrawInProgress"
+          :disable="isWithdrawInProgress"
+          label="Address"
+          lazy-rules
+          :rules="(val) => (val && val.length > 4) || 'Please enter valid address'"
+        />
+        <!-- Fee estimate -->
+        <div class="q-mb-lg">
+          <div v-if="!isNativeToken && isFeeLoading" class="text-caption text-italic">
+            <q-spinner-puff class="q-my-none q-mr-sm" color="primary" size="2rem" />
+            Fetching fee estimate...
+          </div>
+          <div v-else-if="isNativeToken" class="text-caption">
+            Withdrawal fee: <span class="text-bold"> 0 {{ nativeTokenSymbol }} </span>
+          </div>
+          <div v-else-if="activeFee" class="text-caption">
+            Estimated withdrawal fee:
+            <span class="text-bold">
+              {{ humanizeTokenAmount(activeFee.fee, activeFee.token) }}
+              {{ activeFee.token.symbol }}
+            </span>
+          </div>
         </div>
       </div>
-    </div>
-    <div v-else class="text-center q-mb-lg">
-      <q-spinner-puff class="q-mb-md q-mr-sm" color="primary" size="2rem" />
-      <div class="text-center text-italic">Withdraw in progress...</div>
-    </div>
-
-    <!-- Privacy warning -->
-    <div class="border q-mb-lg" />
-    <div class="text-caption">
-      <q-icon name="fas fa-exclamation-triangle" color="warning" left />
-      <span class="text-bold">WARNING</span>: Be sure you understand the security implications before entering a
-      withdrawal address. If you withdraw to an address publicly associated with you, privacy for this transaction will
-      be lost. <router-link class="hyperlink" to="/faq#receiving-funds" target="_blank"> Learn more </router-link>.
+      <div v-else class="text-center q-mb-lg">
+        <q-spinner-puff class="q-mb-md q-mr-sm" color="primary" size="2rem" />
+        <div class="text-center text-italic">Withdraw in progress...</div>
+      </div>
+      <!-- Privacy warning -->
+      <div class="border q-mb-lg" />
+      <div class="text-caption">
+        <q-icon name="fas fa-exclamation-triangle" color="warning" left />
+        <span class="text-bold">WARNING</span>: Be sure you understand the security implications before entering a
+        withdrawal address. If you withdraw to an address publicly associated with you, privacy for this transaction
+        will be lost.
+        <router-link class="hyperlink" to="/faq#receiving-funds" target="_blank"> Learn more </router-link>.
+      </div>
     </div>
 
     <!-- Advanced feature: show private key -->
     <div v-if="advancedMode">
-      <div @click="emit('togglePrivateKey')" class="text-caption hyperlink q-mt-lg">
+      <div @click="emit('togglePrivateKey')" class="text-caption hyperlink">
         {{ spendingPrivateKey ? 'Hide' : 'Show' }} withdrawal private key
       </div>
       <div
@@ -77,6 +79,10 @@ export default defineComponent({
     destinationAddress: {
       type: String,
       required: false,
+    },
+    isWithdrawn: {
+      type: Boolean,
+      required: true,
     },
     isWithdrawInProgress: {
       type: Boolean,

--- a/frontend/src/utils/address.ts
+++ b/frontend/src/utils/address.ts
@@ -96,9 +96,10 @@ export const lookupOrFormatAddresses = async (addresses: string[], provider: Pro
 
 // Checks for any potential risks of withdrawing to the provided name or address, returns object containing
 // a true/false judgement about risk, and HTML strings with details about the warnings
-export const isAddressSafe = async (name: string, userAddress: string, provider: Provider) => {
+export const isAddressSafe = async (name: string, userAddress: string, stealthAddress: string, provider: Provider) => {
   const reasons: string[] = [];
   userAddress = getAddress(userAddress);
+  stealthAddress = getAddress(stealthAddress);
 
   // Check if we're withdrawing to an ENS or CNS name
   const isDomain = utils.isDomain(name);
@@ -117,7 +118,10 @@ export const isAddressSafe = async (name: string, userAddress: string, provider:
   }
 
   // Check if address is the wallet user is logged in with
-  if (destinationAddress === userAddress) reasons.push(`It ${isDomain ? 'resolves to' : 'has'} the same address as the connected wallet`); // prettier-ignore
+  if (destinationAddress === userAddress) reasons.push(`It ${isDomain ? 'resolves to' : 'is'} the same address as the connected wallet`); // prettier-ignore
+
+  // Check if the address is the stealth address that was sent funds
+  if (destinationAddress === stealthAddress) reasons.push(`It ${isDomain ? 'resolves to' : 'is'} the same address as the stealth address`); // prettier-ignore
 
   // Check if address owns any POAPs
   if (await hasPOAPs(destinationAddress)) reasons.push(`${isDomain ? 'The address it resolves to' : 'It'} has POAP tokens`); // prettier-ignore


### PR DESCRIPTION
Changes:
1. When withdrawing, show a warning if you withdraw to the same stealth address
2. On the receive table:
    1. If advanced mode is off, no changes
    2. If advanced mode is on, funds that were previously withdrawn should show a cursor pointer over the green "Withdrawn", and when clicking it the expanded area should be shown with the only action being to show/hide the private key