### PR TITLE
Properly handle response from OZ relayer for all networks

### DIFF
--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -336,7 +336,7 @@ import AccountReceiveTableWarning from 'components/AccountReceiveTableWarning.vu
 import AccountReceiveTableWithdrawConfirmation from 'components/AccountReceiveTableWithdrawConfirmation.vue';
 import BaseTooltip from 'src/components/BaseTooltip.vue';
 import WithdrawForm from 'components/WithdrawForm.vue';
-import { ConfirmedRelayerStatusResponse, FeeEstimateResponse } from 'components/models';
+import { FeeEstimateResponse } from 'components/models';
 import { formatAddress, lookupOrFormatAddresses, toAddress, isAddressSafe } from 'src/utils/address';
 import { MAINNET_PROVIDER } from 'src/utils/constants';
 import { getEtherscanUrl } from 'src/utils/utils';
@@ -594,19 +594,14 @@ function useReceivedFundsTable(announcements: UserAnnouncement[], spendingKeyPai
           relayTransactionHash: string;
         };
 
-        if (chainId === 137) {
-          // No relayer support on this network, so this is a regular transaction hash
-          console.log(`${vm.$i18n.t('AccountReceiveTable.relayed-with-tx-hash').toString()} ${relayTransactionHash}`);
-          const receipt = await provider.value.waitForTransaction(relayTransactionHash);
-          console.log(vm.$i18n.t('AccountReceiveTable.withdraw-successful-receipt'), receipt);
-        } else {
-          // Received a relayer transaction hash, wait for withdraw transaction to be mined
-          console.log(
-            `${vm.$i18n.t('AccountReceiveTable.relayed-with-relayer-id').toString()} ${relayTransactionHash}`
-          );
-          const { receipt } = (await relayer.value?.waitForId(relayTransactionHash)) as ConfirmedRelayerStatusResponse;
-          console.log(vm.$i18n.t('AccountReceiveTable.withdraw-successful-receipt'), receipt);
-        }
+        // This is a regular transaction hash, though it's possible OZ Defender will replace it to ensure it gets
+        // included quickly, in which case the frontend would not automatically reflect when the relay was successful.
+        // Because we relay with the "fast" setting, this is unlikely to be the case.
+        window.logger.info(
+          `${vm.$i18n.t('AccountReceiveTable.relayed-with-tx-hash').toString()} ${relayTransactionHash}`
+        );
+        const receipt = await provider.value.waitForTransaction(relayTransactionHash);
+        window.logger.info(vm.$i18n.t('AccountReceiveTable.withdraw-successful-receipt'), receipt);
       }
 
       // Send complete, cleanup state

--- a/frontend/src/components/models.ts
+++ b/frontend/src/components/models.ts
@@ -151,7 +151,6 @@ export type RelayResponse = { relayTransactionHash: string } | ApiError;
 export type RelayerStatusResponse =
   | { receivedTime: string; broadcasts?: any[]; receipt?: TransactionReceipt }
   | ApiError;
-export type ConfirmedRelayerStatusResponse = { receivedTime: string; broadcasts: any[]; receipt: TransactionReceipt };
 
 // Logger type added to window
 declare global {

--- a/frontend/src/i18n/locales/en-us.json
+++ b/frontend/src/i18n/locales/en-us.json
@@ -227,7 +227,7 @@
     "received": "Received",
     "withdrawn": "Withdrawn",
     "hide": "Hide",
-    "withdraw": "withdraw",
+    "withdraw": "Withdraw",
     "receiver": "Receiver",
     "scanning-complete": "Scanning completed successfully",
     "custom-prv-key": " with custom private key",

--- a/frontend/src/utils/umbra-api.ts
+++ b/frontend/src/utils/umbra-api.ts
@@ -4,7 +4,6 @@
 
 import { JsonRpcProvider } from 'src/utils/ethers';
 import {
-  ConfirmedRelayerStatusResponse,
   FeeEstimateResponse,
   RelayerStatusResponse,
   Provider,
@@ -72,28 +71,4 @@ export class UmbraApi {
     if ('error' in data) throw new Error(`Could not get relay status: ${data.error}`);
     return data;
   }
-
-  // Returns a promise that resolves once the specified relayer transaction has mined
-  async waitForId(itxId: string) {
-    let result;
-    while (!result) {
-      try {
-        // Return response if it contains a receipt (i.e. it was mined)
-        const response = await this.getRelayStatus(itxId);
-        if ('receipt' in response && response.receipt) {
-          result = response as ConfirmedRelayerStatusResponse;
-        }
-      } catch (err) {
-        // If there was an error, log it, but keep trying
-        console.warn(`Received the below error when fetching status for relayer ID ${itxId}`);
-        console.warn(err);
-      } finally {
-        // Wait 4 seconds and try again
-        await sleep(4000);
-      }
-    }
-    return result;
-  }
 }
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
Removes special case handling of relayer response and assumes response is always a regular transaction hash.

**Must be merged and deployed at the same time as** https://github.com/ScopeLift/umbra-api/pull/54