### PR TITLE
update: unstoppable domains resolution library

### DIFF
--- a/umbra-js/package.json
+++ b/umbra-js/package.json
@@ -23,7 +23,7 @@
   "author": "Matt Solomon <matt@mattsolomon.dev>, Ben DiFrancesco <ben@scopelift.co>",
   "license": "ISC",
   "dependencies": {
-    "@unstoppabledomains/resolution": "3.0.0",
+    "@unstoppabledomains/resolution": "^7.1.4",
     "ethers": "^5.5.3",
     "noble-secp256k1": "^1.2.5"
   },

--- a/umbra-js/src/utils/utils.ts
+++ b/umbra-js/src/utils/utils.ts
@@ -20,7 +20,7 @@ import {
 } from '../ethers';
 import { Point, Signature, recoverPublicKey } from 'noble-secp256k1';
 import { ens, cns } from '..';
-import { default as Resolution, Eip1993Factories } from '@unstoppabledomains/resolution';
+import { default as Resolution } from '@unstoppabledomains/resolution';
 import { StealthKeyRegistry } from '../classes/StealthKeyRegistry';
 import { TxHistoryProvider } from '../classes/TxHistoryProvider';
 import { EthersProvider, TransactionResponseExtended } from '../types';
@@ -283,9 +283,9 @@ function getResolutionInstance(provider: EthersProvider) {
   const networkName = provider.network.name === 'homestead' ? 'mainnet' : provider.network.name;
   return new Resolution({
     sourceConfig: {
-      cns: {
-        provider: Eip1993Factories.fromEthersProvider(provider),
-        network: networkName as 'mainnet' | 'rinkeby',
+      uns: {
+        api: true,
+        network: networkName === 'mainnet' ? 1 : 4,
       },
     },
   });
@@ -414,7 +414,7 @@ async function getTransactionByHash(txHash: string, provider: EthersProvider): P
   ]);
   const tx = <TransactionResponseExtended>{ ...partialTx };
   const existingFields = new Set(Object.keys(tx));
-  Object.keys(fullTx).forEach((key) => {
+  Object.keys(fullTx).forEach(key => {
     // Do nothing if this field already exists (i.e. it was formatted by the ethers formatter).
     if (existingFields.has(key)) return;
     // Otherwise, add the field and format it

--- a/umbra-js/src/utils/utils.ts
+++ b/umbra-js/src/utils/utils.ts
@@ -20,7 +20,7 @@ import {
 } from '../ethers';
 import { Point, Signature, recoverPublicKey } from 'noble-secp256k1';
 import { ens, cns } from '..';
-import { default as Resolution } from '@unstoppabledomains/resolution';
+import { default as Resolution, Eip1993Factories } from '@unstoppabledomains/resolution';
 import { StealthKeyRegistry } from '../classes/StealthKeyRegistry';
 import { TxHistoryProvider } from '../classes/TxHistoryProvider';
 import { EthersProvider, TransactionResponseExtended } from '../types';
@@ -279,13 +279,22 @@ export function isDomain(name: string) {
  * @param provider ethers provider instance
  */
 function getResolutionInstance(provider: EthersProvider) {
-  // If network name is homestead, use 'mainnet' as the network name
-  const networkName = provider.network.name === 'homestead' ? 'mainnet' : provider.network.name;
+  const eip1993Provider = Eip1993Factories.fromEthersProvider(provider);
   return new Resolution({
     sourceConfig: {
       uns: {
-        api: true,
-        network: networkName === 'mainnet' ? 1 : 4,
+        locations: {
+          Layer1: {
+            network: 'mainnet',
+            provider: eip1993Provider,
+            proxyReaderAddress: '0x58034A288D2E56B661c9056A0C27273E5460B63c',
+          },
+          Layer2: {
+            network: 'polygon',
+            provider: eip1993Provider,
+            proxyReaderAddress: '0x423F2531bd5d3C3D4EF7C318c2D1d9BEDE67c680',
+          },
+        },
       },
     },
   });

--- a/umbra-js/test/cns.test.ts
+++ b/umbra-js/test/cns.test.ts
@@ -6,11 +6,22 @@ import * as cns from '../src/utils/cns';
 import { expectRejection } from './utils';
 
 const ethersProvider = ethers.provider;
+const eip1993Provider = Eip1993Factories.fromEthersProvider(ethersProvider);
 const resolution = new Resolution({
   sourceConfig: {
-    cns: {
-      provider: Eip1993Factories.fromEthersProvider(ethersProvider),
-      network: 'rinkeby',
+    uns: {
+      locations: {
+        Layer1: {
+          network: 'mainnet',
+          provider: eip1993Provider,
+          proxyReaderAddress: '0x1BDc0fD4fbABeed3E611fd6195fCd5d41dcEF393',
+        },
+        Layer2: {
+          network: 'polygon',
+          provider: eip1993Provider,
+          proxyReaderAddress: '0x3E67b8c702a1292d1CEb025494C84367fcb12b45',
+        },
+      },
     },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5052,18 +5052,17 @@
   resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.21.tgz#5a4844236e328d3b0e87161c19edaace669e3e6e"
   integrity sha512-IQ1YpWKgXIsfYqym9Nl/uaB1t5Wk70pyqJ2W4FmvQmt3FIQz+pHlzlEl91aYloPrlcZaFluE0Jq7gkfYpIjsBw==
 
-"@unstoppabledomains/resolution@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@unstoppabledomains/resolution/-/resolution-3.0.0.tgz#148080757f3ab2e94993228a5934ea60f1e0807b"
-  integrity sha512-iAvVkDWsSdi9WOiCp8t6GwWQZYIQjca+JAzfnNB7LvRDim3jrgcLlbeSYu+Mwzn2JKUGf/Ygw7YtnmjihnT5fw==
+"@unstoppabledomains/resolution@^7.1.4":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@unstoppabledomains/resolution/-/resolution-7.1.4.tgz#f3f0f9d2f36b88bf0a3af92c26731a01e5dba94b"
+  integrity sha512-GdXLpP+oRk4lLWMISo7g7gPyKoCONyLoQtYH6GVhXtyY9t+CeHJW2kZ/btcbXg0lmEO6PSr5yYOlDz4wRCq2RA==
   dependencies:
     "@ethersproject/abi" "^5.0.1"
     bn.js "^4.4.0"
-    commander "^4.1.1"
-    ethereum-ens-network-map "^1.0.2"
+    cross-fetch "^3.1.4"
+    elliptic "^6.5.4"
     js-sha256 "^0.9.0"
     js-sha3 "^0.8.0"
-    node-fetch "^2.6.0"
 
 "@vue/component-compiler-utils@^3.1.0":
   version "3.2.0"
@@ -8628,6 +8627,13 @@ cross-fetch@^2.1.0, cross-fetch@^2.1.1:
     node-fetch "^2.6.7"
     whatwg-fetch "^2.0.4"
 
+cross-fetch@^3.1.4:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
+
 cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -10652,11 +10658,6 @@ ethereum-cryptography@^0.1.2, ethereum-cryptography@^0.1.3:
     scrypt-js "^3.0.0"
     secp256k1 "^4.0.1"
     setimmediate "^1.0.5"
-
-ethereum-ens-network-map@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ethereum-ens-network-map/-/ethereum-ens-network-map-1.0.2.tgz#4e27bad18dae7bd95d84edbcac2c9e739fc959b9"
-  integrity sha512-5qwJ5n3YhjSpE6O/WEBXCAb2nagUgyagJ6C0lGUBWC4LjKp/rRzD+pwtDJ6KCiITFEAoX4eIrWOjRy0Sylq5Hg==
 
 ethereum-ens@^0.8.0:
   version "0.8.0"
@@ -16612,7 +16613,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@2.6.7, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -24128,10 +24129,20 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-y18n@^3.2.1, y18n@^4.0.0, y18n@^4.0.1, y18n@^5.0.5:
+y18n@^3.2.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.2.tgz#85c901bd6470ce71fc4bb723ad209b70f7f28696"
+  integrity sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==
+
+y18n@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yaeti@^0.0.6:
   version "0.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24129,20 +24129,10 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-y18n@^3.2.1:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.2.tgz#85c901bd6470ce71fc4bb723ad209b70f7f28696"
-  integrity sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==
-
-y18n@^4.0.0:
+y18n@^3.2.1, y18n@^4.0.0, y18n@^4.0.1, y18n@^5.0.5:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
-
-y18n@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
-  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yaeti@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
## Why?
To support new unstoppable domain names and domains minted on polygon
## Modified files:
- update @unstoppabledomains/resolution to v7.1.4 (in umbra-js/package.json)
- modify getResolutionInstance to fit new typings (in umbra-js/src/utils/utils.ts)