### PR TITLE
Add English to certain Chinese error messages and alerts

### DIFF
--- a/frontend/src/i18n/locales/en-us.json
+++ b/frontend/src/i18n/locales/en-us.json
@@ -228,10 +228,7 @@
     "withdrawn": "Withdrawn",
     "hide": "Hide",
     "withdraw": "Withdraw",
-<<<<<<< HEAD
-=======
     "receiver": "Receiver",
->>>>>>> 9fd6437 (Add English to certain Chinese error messages)
     "scanning-complete": "Scanning completed successfully",
     "custom-prv-key": " with custom private key",
     "scanned-from-block": "Scanned from block",

--- a/frontend/src/i18n/locales/en-us.json
+++ b/frontend/src/i18n/locales/en-us.json
@@ -228,6 +228,10 @@
     "withdrawn": "Withdrawn",
     "hide": "Hide",
     "withdraw": "Withdraw",
+<<<<<<< HEAD
+=======
+    "receiver": "Receiver",
+>>>>>>> 9fd6437 (Add English to certain Chinese error messages)
     "scanning-complete": "Scanning completed successfully",
     "custom-prv-key": " with custom private key",
     "scanned-from-block": "Scanned from block",

--- a/frontend/src/i18n/locales/zh-cn.json
+++ b/frontend/src/i18n/locales/zh-cn.json
@@ -227,12 +227,8 @@
     "received": "已收到(Received)",
     "withdrawn": "已提取(Withdrawn)",
     "hide": "隐藏",
-<<<<<<< HEAD
-    "withdraw": "提取",
-=======
     "withdraw": "提取(Withdraw)",
     "receiver": "接受者",
->>>>>>> 9fd6437 (Add English to certain Chinese error messages)
     "scanning-complete": "扫描已成功完成",
     "custom-prv-key": "使用自定义私钥",
     "scanned-from-block": "从此块扫描",

--- a/frontend/src/i18n/locales/zh-cn.json
+++ b/frontend/src/i18n/locales/zh-cn.json
@@ -222,12 +222,17 @@
     "scan-settings": "更改扫描设置",
     "account-empty": "此帐户尚未收到任何资金",
     "received-funds": "收到的资金",
-    "sender": "发送者",
-    "stealth-receiver": "隐形接收者",
-    "received": "已收到",
-    "withdrawn": "已提取",
+    "sender": "发送者(Sender)",
+    "stealth-receiver": "隐形接收者(Stealth Receiver)",
+    "received": "已收到(Received)",
+    "withdrawn": "已提取(Withdrawn)",
     "hide": "隐藏",
+<<<<<<< HEAD
     "withdraw": "提取",
+=======
+    "withdraw": "提取(Withdraw)",
+    "receiver": "接受者",
+>>>>>>> 9fd6437 (Add English to certain Chinese error messages)
     "scanning-complete": "扫描已成功完成",
     "custom-prv-key": "使用自定义私钥",
     "scanned-from-block": "从此块扫描",
@@ -292,9 +297,9 @@
   },
   "Utils": {
     "Alerts": {
-      "transaction-pending": "正在处理您的交易",
-      "transaction-succeeded": "您的交易已成功",
-      "transaction-failed": "您的交易已失败"
+      "transaction-pending": "正在处理您的交易(Your transaction is pending)",
+      "transaction-succeeded": "您的交易已成功(Your transaction has succeeded)",
+      "transaction-failed": "您的交易已失败(Your transaction has failed)"
     },
     "Address": {
       "name-publicly-viewable": "此名称可公开查看",


### PR DESCRIPTION
When users who use the Chinese version of the site ask for help in the #help channel, there's an additional burden on the customer support team to ask for English translations of certain error and notification messages. Therefore, I've added English translations to some of the Chinese locale messages as shown below:
 
![Receive table](https://user-images.githubusercontent.com/61768337/175987999-37cf87e4-900d-4f4b-b7f1-9fac15cb0780.png)
![transaction msg](https://user-images.githubusercontent.com/61768337/175988013-dee86f58-d311-4aed-8561-3a8768f8ffce.png)

