### PR TITLE
Stop using ethers default api keys

### DIFF
--- a/umbra-js/test/utils.test.ts
+++ b/umbra-js/test/utils.test.ts
@@ -1,11 +1,14 @@
 import { ethers } from 'hardhat';
-import { getDefaultProvider } from '@ethersproject/providers';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { expect } from 'chai';
 import * as utils from '../src/utils/utils';
 import type { EthersProvider } from '../src/types';
 import { expectRejection } from './utils';
 
 const ethersProvider = ethers.provider;
+
+const infura = process.env.INFURA_ID;
+if (!infura) throw new Error('Please set your INFURA_ID in a .env file');
 
 // Public key and address corresponding to msolomon.eth
 const publicKey = '0x04df3d784d6d1e55fabf44b7021cf17c00a6cccc53fea00d241952ac2eebc46dc674c91e60ccd97576c1ba2a21beed21f7b02aee089f2eeec357ffd349488a7cee'; // prettier-ignore
@@ -94,21 +97,21 @@ describe('Utilities', () => {
 
     // --- Address, advanced mode on (i.e. don't use the StealthKeyRegistry) ---
     it('looks up recipients by address, advanced mode on', async () => {
-      const ethersProvider = getDefaultProvider('rinkeby') as EthersProvider;
+      const ethersProvider = new StaticJsonRpcProvider(`https://rinkeby.infura.io/v3/${String(process.env.INFURA_ID)}`);
       const keys = await utils.lookupRecipient(address, ethersProvider, { advanced: true });
       expect(keys.spendingPublicKey).to.equal(pubKeysWallet.spendingPublicKey);
       expect(keys.viewingPublicKey).to.equal(pubKeysWallet.viewingPublicKey);
     });
 
     it('looks up recipients by ENS, advanced mode on', async () => {
-      const ethersProvider = getDefaultProvider('rinkeby') as EthersProvider;
+      const ethersProvider = new StaticJsonRpcProvider(`https://rinkeby.infura.io/v3/${String(process.env.INFURA_ID)}`);
       const keys = await utils.lookupRecipient('msolomon.eth', ethersProvider, { advanced: true });
       expect(keys.spendingPublicKey).to.equal(pubKeysWallet.spendingPublicKey);
       expect(keys.viewingPublicKey).to.equal(pubKeysWallet.viewingPublicKey);
     });
 
     it('looks up recipients by CNS, advanced mode on', async () => {
-      const ethersProvider = getDefaultProvider('rinkeby') as EthersProvider;
+      const ethersProvider = new StaticJsonRpcProvider(`https://rinkeby.infura.io/v3/${String(process.env.INFURA_ID)}`);
       const keys = await utils.lookupRecipient('udtestdev-msolomon.crypto', ethersProvider, { advanced: true });
       expect(keys.spendingPublicKey).to.equal(pubKeysWallet.spendingPublicKey);
       expect(keys.viewingPublicKey).to.equal(pubKeysWallet.viewingPublicKey);
@@ -116,7 +119,7 @@ describe('Utilities', () => {
 
     // --- Address, advanced mode off (i.e. use the StealthKeyRegistry) ---
     it('looks up recipients by address, advanced mode off', async () => {
-      const ethersProvider = getDefaultProvider('rinkeby') as EthersProvider; // otherwise throws with unsupported network since we're on localhost
+      const ethersProvider = new StaticJsonRpcProvider(`https://rinkeby.infura.io/v3/${String(process.env.INFURA_ID)}`); // otherwise throws with unsupported network since we're on localhost
       const keys = await utils.lookupRecipient(address, ethersProvider);
       expect(keys.spendingPublicKey).to.equal(pubKeysUmbra.spendingPublicKey);
       expect(keys.viewingPublicKey).to.equal(pubKeysUmbra.viewingPublicKey);
@@ -128,7 +131,7 @@ describe('Utilities', () => {
     });
 
     it('looks up recipients by ENS, advanced mode off', async () => {
-      const ethersProvider = getDefaultProvider('rinkeby') as EthersProvider;
+      const ethersProvider = new StaticJsonRpcProvider(`https://rinkeby.infura.io/v3/${String(process.env.INFURA_ID)}`);
       const keys = await utils.lookupRecipient('msolomon.eth', ethersProvider);
       // These values are set on the Rinkeby resolver
       expect(keys.spendingPublicKey).to.equal(pubKeysUmbra.spendingPublicKey);
@@ -154,13 +157,13 @@ describe('Utilities', () => {
 
     // --- Address history by network ---
     it('looks up transaction history on mainnet', async () => {
-      const ethersProvider = getDefaultProvider('mainnet') as EthersProvider;
+      const ethersProvider = new StaticJsonRpcProvider(`https://mainnet.infura.io/v3/${String(process.env.INFURA_ID)}`);
       const txHash = await utils.getSentTransaction(address, ethersProvider);
       expect(txHash).to.have.lengthOf(66);
     });
 
     it('looks up transaction history on rinkeby', async () => {
-      const ethersProvider = getDefaultProvider('rinkeby') as EthersProvider;
+      const ethersProvider = new StaticJsonRpcProvider(`https://rinkeby.infura.io/v3/${String(process.env.INFURA_ID)}`);
       const txHash = await utils.getSentTransaction(address, ethersProvider);
       expect(txHash).to.have.lengthOf(66);
     });
@@ -209,7 +212,7 @@ describe('Utilities', () => {
 
     it('throws when looking up an address that has not sent a transaction', async () => {
       const address = '0x0000000000000000000000000000000000000002';
-      const ethersProvider = getDefaultProvider('rinkeby') as EthersProvider; // otherwise throws with unsupported network since we're on localhost
+      const ethersProvider = new StaticJsonRpcProvider(`https://rinkeby.infura.io/v3/${String(process.env.INFURA_ID)}`); // otherwise throws with unsupported network since we're on localhost
       const errorMsg = `Address ${address} has not registered stealth keys. Please ask them to setup their Umbra account`;
       await expectRejection(utils.lookupRecipient(address, ethersProvider), errorMsg);
     });


### PR DESCRIPTION
Switch to static provider with our infura id env var injected to avoid rate limiting associated with the default provider.