### PR TITLE
fix: clear all state on network/address change by refreshing

### DIFF
--- a/frontend/src/store/wallet.ts
+++ b/frontend/src/store/wallet.ts
@@ -83,14 +83,14 @@ export default function useWalletStore() {
           wallet: (wallet) => {
             setProvider(wallet.provider);
           },
-          address: async (address) => {
+          address: (address) => {
             if (address && userAddress.value && userAddress.value !== getAddress(address)) {
-              await configureProvider();
+              window.location.reload();
             }
           },
-          network: async (newChainId) => {
+          network: (newChainId) => {
             if (chainId.value && chainId.value !== newChainId) {
-              await configureProvider();
+              window.location.reload();
             }
           },
         },


### PR DESCRIPTION
Sometimes refreshing during a scan was slow (guess it needs to wait for the event loop to free up to refresh? not certain), but otherwise this seems to work as you'd expect by refreshing when you change address or network. Network changes from the app or from the wallet should both work