### PR TITLE
ci/fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,10 +72,11 @@ jobs:
 
       - name: Run coverage
         run: yarn coverage
+
       - name: Merge directories
         run: |
           sudo apt update && sudo apt install -y lcov
-          lcov --add-tracefile ./contracts-periphery/lcov.info --add-tracefile ./umbra-js/coverage/lcov.info  --output-file lcov.info
+          lcov --add-tracefile ./contracts-periphery/lcov.info --add-tracefile ./umbra-js/coverage/lcov.info  --output-file lcov.info --rc lcov_branch_coverage=1
 
       # To ignore coverage for certain directories modify the paths in this step as needed. The
       # below default ignores coverage results for the test and script directories. Alternatively,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-      FOUNDRY_PROFILE: ci
+  FOUNDRY_PROFILE: ci
 
 jobs:
   build:
@@ -90,7 +90,7 @@ jobs:
         uses: zgosalvez/github-actions-report-lcov@v1
         with:
           coverage-files: ./lcov.info
-          minimum-coverage: 50 # Set coverage threshold.
+          minimum-coverage: 70 # Set coverage threshold.
           github-token: ${{ secrets.GITHUB_TOKEN }} # Adds a coverage summary comment to the PR.
 
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
         run: |
           lcov --remove ./lcov.info 'contracts-periphery/test/*' 'contracts-periphery/script/*'
       - name: Verify coverage level
-        uses: zgosalvez/github-actions-report-lcov@v1
+        uses: zgosalvez/github-actions-report-lcov@v2
         with:
           coverage-files: ./lcov.info
           minimum-coverage: 70 # Set coverage threshold.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,9 +5,6 @@ on:
       - main
   pull_request:
 
-env:
-  FOUNDRY_PROFILE: ci
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,6 +26,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     env:
+      FOUNDRY_PROFILE: ci
       ETH_RPC_URL: ${{ secrets.ETH_RPC_URL }}
       INFURA_ID: ${{ secrets.INFURA_ID }}
       ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
 
+env:
+  FOUNDRY_PROFILE: ci
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +29,6 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     env:
-      FOUNDRY_PROFILE: ci
       ETH_RPC_URL: ${{ secrets.ETH_RPC_URL }}
       INFURA_ID: ${{ secrets.INFURA_ID }}
       ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
 
+env:
+      FOUNDRY_PROFILE: ci
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,7 +29,6 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     env:
-      FOUNDRY_PROFILE: ci
       ETH_RPC_URL: ${{ secrets.ETH_RPC_URL }}
       INFURA_ID: ${{ secrets.INFURA_ID }}
       ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
         uses: zgosalvez/github-actions-report-lcov@v1
         with:
           coverage-files: ./lcov.info
-          minimum-coverage: 0 # Set coverage threshold.
+          minimum-coverage: 50 # Set coverage threshold.
           github-token: ${{ secrets.GITHUB_TOKEN }} # Adds a coverage summary comment to the PR.
 
   lint:

--- a/contracts-periphery/.gitignore
+++ b/contracts-periphery/.gitignore
@@ -1,2 +1,3 @@
 cache/
 out/
+*lcov*

--- a/contracts-periphery/Makefile
+++ b/contracts-periphery/Makefile
@@ -13,4 +13,4 @@ install :; $(INSTALL_CMD)
 test :; forge test
 test-gas :; forge test --match-path *.gas.t.sol
 snapshot-gas :; forge test --match-path *.gas.t.sol --gas-report > snapshot/.gas
-coverage :; forge coverage --report lcov && sed -i'.bak' 's/SF:/SF:contracts-periphery\//gI' lcov.info
+coverage :; forge coverage --report lcov --report summary && sed -i'.bak' 's/SF:/SF:contracts-periphery\//gI' lcov.info

--- a/contracts-periphery/foundry.toml
+++ b/contracts-periphery/foundry.toml
@@ -13,10 +13,10 @@
 [profile.lite]
   fuzz = { runs = 50 }
   invariant = { runs = 10 }
-  optimizer = false         # Speed up compilation and tests during development.
+  # Speed up compilation and tests during development.
+  optimizer = false
 
 [profile.ci]
-  deny_warnings = true        # fails build if there are compiler warnings
   fuzz = { runs = 10000 }
   invariant = { runs = 1000 }
 

--- a/contracts-periphery/foundry.toml
+++ b/contracts-periphery/foundry.toml
@@ -13,10 +13,10 @@
 [profile.lite]
   fuzz = { runs = 50 }
   invariant = { runs = 10 }
-  # Speed up compilation and tests during development.
-  optimizer = false
+  optimizer = false         # Speed up compilation and tests during development.
 
 [profile.ci]
+  deny_warnings = true        # fails build if there are compiler warnings
   fuzz = { runs = 10000 }
   invariant = { runs = 1000 }
 

--- a/umbra-js/test/utils.test.ts
+++ b/umbra-js/test/utils.test.ts
@@ -178,14 +178,16 @@ describe('Utilities', () => {
     });
 
     it('looks up transaction history on polygon', async () => {
-      const ethersProvider = new ethers.providers.StaticJsonRpcProvider('https://polygon-rpc.com') as EthersProvider;
+      const ethersProvider = new ethers.providers.StaticJsonRpcProvider(
+        `https://polygon-mainnet.infura.io/v3/${INFURA_ID}`
+      ) as EthersProvider;
       const txHash = await utils.getSentTransaction(address, ethersProvider);
       expect(txHash).to.have.lengthOf(66);
     });
 
     it('looks up transaction history on optimism', async () => {
       const ethersProvider = new ethers.providers.StaticJsonRpcProvider(
-        'https://mainnet.optimism.io'
+        `https://optimism-mainnet.infura.io/v3/${INFURA_ID}`
       ) as EthersProvider;
       const txHash = await utils.getSentTransaction(address, ethersProvider);
       expect(txHash).to.have.lengthOf(66);
@@ -193,7 +195,7 @@ describe('Utilities', () => {
 
     it('looks up transaction history on arbitrum one', async () => {
       const ethersProvider = new ethers.providers.StaticJsonRpcProvider(
-        'https://arb1.arbitrum.io/rpc'
+        `https://arbitrum-mainnet.infura.io/v3/${INFURA_ID}`
       ) as EthersProvider;
       const txHash = await utils.getSentTransaction(address, ethersProvider);
       expect(txHash).to.have.lengthOf(66);

--- a/umbra-js/test/utils.test.ts
+++ b/umbra-js/test/utils.test.ts
@@ -7,8 +7,8 @@ import { expectRejection } from './utils';
 
 const ethersProvider = ethers.provider;
 
-const infura = process.env.INFURA_ID;
-if (!infura) throw new Error('Please set your INFURA_ID in a .env file');
+const INFURA_ID = <string>process.env.INFURA_ID;
+if (!INFURA_ID) throw new Error('Please set your INFURA_ID in a .env file');
 
 // Public key and address corresponding to msolomon.eth
 const publicKey = '0x04df3d784d6d1e55fabf44b7021cf17c00a6cccc53fea00d241952ac2eebc46dc674c91e60ccd97576c1ba2a21beed21f7b02aee089f2eeec357ffd349488a7cee'; // prettier-ignore
@@ -119,7 +119,7 @@ describe('Utilities', () => {
     });
 
     it.skip('looks up recipients by CNS, advanced mode on', async () => {
-      const ethersProvider = new StaticJsonRpcProvider(`https://goerli.infura.io/v3/${String(process.env.INFURA_ID)}`);
+      const ethersProvider = new StaticJsonRpcProvider(`https://goerli.infura.io/v3/${INFURA_ID}`);
       const keys = await utils.lookupRecipient('udtestdev-msolomon.crypto', ethersProvider, { advanced: true });
       expect(keys.spendingPublicKey).to.equal(pubKeysWallet.spendingPublicKey);
       expect(keys.viewingPublicKey).to.equal(pubKeysWallet.viewingPublicKey);
@@ -127,7 +127,7 @@ describe('Utilities', () => {
 
     // --- Address, advanced mode off (i.e. use the StealthKeyRegistry) ---
     it('looks up recipients by address, advanced mode off', async () => {
-      const ethersProvider = new StaticJsonRpcProvider(`https://goerli.infura.io/v3/${String(process.env.INFURA_ID)}`); // otherwise throws with unsupported network since we're on localhost
+      const ethersProvider = new StaticJsonRpcProvider(`https://goerli.infura.io/v3/${INFURA_ID}`); // otherwise throws with unsupported network since we're on localhost
       const keys = await utils.lookupRecipient(address, ethersProvider);
       expect(keys.spendingPublicKey).to.equal(pubKeysUmbra.spendingPublicKey);
       expect(keys.viewingPublicKey).to.equal(pubKeysUmbra.viewingPublicKey);
@@ -139,7 +139,7 @@ describe('Utilities', () => {
     });
 
     it('looks up recipients by ENS, advanced mode off', async () => {
-      const ethersProvider = new StaticJsonRpcProvider(`https://goerli.infura.io/v3/${String(process.env.INFURA_ID)}`);
+      const ethersProvider = new StaticJsonRpcProvider(`https://goerli.infura.io/v3/${INFURA_ID}`);
       const keys = await utils.lookupRecipient('msolomon.eth', ethersProvider);
       // These values are set on the Goerli resolver
       expect(keys.spendingPublicKey).to.equal(pubKeysUmbra.spendingPublicKey);
@@ -166,13 +166,13 @@ describe('Utilities', () => {
 
     // --- Address history by network ---
     it('looks up transaction history on mainnet', async () => {
-      const ethersProvider = new StaticJsonRpcProvider(`https://mainnet.infura.io/v3/${String(process.env.INFURA_ID)}`);
+      const ethersProvider = new StaticJsonRpcProvider(`https://mainnet.infura.io/v3/${INFURA_ID}`);
       const txHash = await utils.getSentTransaction(address, ethersProvider);
       expect(txHash).to.have.lengthOf(66);
     });
 
     it('looks up transaction history on goerli', async () => {
-      const ethersProvider = new StaticJsonRpcProvider(`https://goerli.infura.io/v3/${String(process.env.INFURA_ID)}`);
+      const ethersProvider = new StaticJsonRpcProvider(`https://goerli.infura.io/v3/${INFURA_ID}`);
       const txHash = await utils.getSentTransaction(address, ethersProvider);
       expect(txHash).to.have.lengthOf(66);
     });
@@ -221,7 +221,7 @@ describe('Utilities', () => {
 
     it('throws when looking up an address that has not sent a transaction', async () => {
       const address = '0x0000000000000000000000000000000000000002';
-      const ethersProvider = new StaticJsonRpcProvider(`https://goerli.infura.io/v3/${String(process.env.INFURA_ID)}`); // otherwise throws with unsupported network since we're on localhost
+      const ethersProvider = new StaticJsonRpcProvider(`https://goerli.infura.io/v3/${INFURA_ID}`); // otherwise throws with unsupported network since we're on localhost
       const errorMsg = `Address ${address} has not registered stealth keys. Please ask them to setup their Umbra account`;
       await expectRejection(utils.lookupRecipient(address, ethersProvider), errorMsg);
     });


### PR DESCRIPTION
## Fixes flaky umbra-js test

Previously we used public RPCs in tests, but the arbitrum one was flaky and not finding a tx that did exist. As a result we got this failure:

```
  1) Utilities
       Recipient identifier lookups
         looks up transaction history on arbitrum one:
     Error: Transaction hash not found. Are the provider and transaction hash on the same network?
      at getTransactionByHash (src/utils/utils.ts:397:11)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at Object.getSentTransaction (src/utils/utils.ts:148:24)
      at Context.<anonymous> (test/utils.test.ts:198:22)
```

Replacing the public RPC with Infura resolved it, so I also made that change for the other RPCs

## CI Coverage Fixes

- Added `--rc lcov_branch_coverage=1` to the `lcov` filtering command. This keeps branch coverage information in the output lcov file (for some reason the default is to remove it), and this seems to have fixed the CI action
- I used the results to set the threshold to 70%
- Modified the `contracts-periphery` coverage command to `forge coverage --report lcov --report summary`. This means it will both (1) output an lcov file, and (2) print the summary table. This is useful because lcov just gives a high level summary, so printing the table too means we can view the CI job logs for more granular info