### PR TITLE
chore/update noble secp256k1

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
         '@typescript-eslint/no-var-requires': 'off',
         '@typescript-eslint/unbound-method': ['error', { ignoreStatic: true }],
         '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
+        '@typescript-eslint/restrict-template-expressions': 'error',
         'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
       },
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umbra/frontend",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Send and receive stealth payments with the Umbra protocol",
   "productName": "Umbra",
   "author": "Matt Solomon <matt@mattsolomon.dev>",

--- a/frontend/src/boot/logger.ts
+++ b/frontend/src/boot/logger.ts
@@ -10,6 +10,6 @@ import { LogLevel } from 'src/utils/ethers';
 // Source: https://github.com/ethers-io/ethers.js/blob/d395d16fa357ec5dda9b59922cf21c39dc34c071/packages/logger/src.ts/index.ts#L44-L49
 UmbraLogger.setLogLevel((process.env.LOG_LEVEL as LogLevel) || LogLevel.DEBUG);
 
-const version = '2.0.0'; // must match package.json version
+const version = '2.0.1'; // must match package.json version
 const logger = new UmbraLogger(version);
 window.logger = logger;

--- a/umbra-js/.eslintrc.js
+++ b/umbra-js/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: '../.eslintrc',
+  extends: '../.eslintrc.js',
   parserOptions: {
     project: 'tsconfig.json',
     parser: '@typescript-eslint/parser',

--- a/umbra-js/package.json
+++ b/umbra-js/package.json
@@ -24,9 +24,9 @@
   "author": "ScopeLift <support@umbra.cash>",
   "license": "MIT",
   "dependencies": {
+    "@noble/secp256k1": "^1.7.1",
     "@unstoppabledomains/resolution": "8.3.1",
-    "ethers": "5.6.9",
-    "noble-secp256k1": "^1.2.5"
+    "ethers": "5.6.9"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",

--- a/umbra-js/src/classes/KeyPair.ts
+++ b/umbra-js/src/classes/KeyPair.ts
@@ -2,7 +2,7 @@
  * @dev Class for managing secp256k1 keys and performing operations with them
  */
 
-import { getSharedSecret as secpGetSharedSecret, utils, getPublicKey, Point, CURVE } from 'noble-secp256k1';
+import { getSharedSecret as secpGetSharedSecret, utils, getPublicKey, Point, CURVE } from '@noble/secp256k1';
 import { BigNumberish, computeAddress, hexlify, hexZeroPad, isHexString, sha256, BigNumber } from '../ethers';
 import { RandomNumber } from './RandomNumber';
 import { assertValidPoint, lengths, recoverPublicKeyFromTransaction } from '../utils/utils';

--- a/umbra-js/src/classes/KeyPair.ts
+++ b/umbra-js/src/classes/KeyPair.ts
@@ -2,7 +2,7 @@
  * @dev Class for managing secp256k1 keys and performing operations with them
  */
 
-import { getSharedSecret as secpGetSharedSecret, utils, getPublicKey, Point, CURVE } from '@noble/secp256k1';
+import { getSharedSecret as secpGetSharedSecret, utils as nobleUtils, getPublicKey, Point, CURVE } from '@noble/secp256k1';
 import { BigNumberish, computeAddress, hexlify, hexZeroPad, isHexString, sha256, BigNumber } from '../ethers';
 import { RandomNumber } from './RandomNumber';
 import { assertValidPoint, lengths, recoverPublicKeyFromTransaction } from '../utils/utils';
@@ -22,6 +22,7 @@ const blockedKeys = [
  * @returns 32-byte shared secret as 66 character hex string
  */
 function getSharedSecret(privateKey: string, publicKey: string) {
+
   assertValidPoint(publicKey);
   if (privateKey.length !== lengths.privateKey || !isHexString(privateKey)) throw new Error('Invalid private key');
   if (publicKey.length !== lengths.publicKey || !isHexString(publicKey)) throw new Error('Invalid public key');
@@ -100,7 +101,7 @@ export class KeyPair {
       throw new Error('Must provide instance of RandomNumber');
     }
     // Get shared secret to use as encryption key
-    const ephemeralPrivateKey = hexlify(utils.randomPrivateKey()); // private key as hex with 0x prefix
+    const ephemeralPrivateKey = hexlify(nobleUtils.randomPrivateKey()); // private key as hex with 0x prefix
     const ephemeralPublicKey = `0x${getPublicKey(ephemeralPrivateKey.slice(2))}`; // public key as hex with 0x prefix
     const sharedSecret = getSharedSecret(ephemeralPrivateKey, this.publicKeyHex);
 

--- a/umbra-js/src/classes/RandomNumber.ts
+++ b/umbra-js/src/classes/RandomNumber.ts
@@ -4,7 +4,7 @@
  */
 
 import { BigNumber, hexZeroPad } from '../ethers';
-import { utils } from 'noble-secp256k1';
+import { utils } from '@noble/secp256k1';
 
 export class RandomNumber {
   readonly sizeInBytes = 32; // generated random number will always be 32 bytes

--- a/umbra-js/src/utils/cns.ts
+++ b/umbra-js/src/utils/cns.ts
@@ -1,7 +1,7 @@
 /**
  * @dev Functions for interacting with the Unstoppable Domains Crypto Name Service (CNS)
  */
-import { Point } from 'noble-secp256k1';
+import { Point } from '@noble/secp256k1';
 import { default as Resolution, NamingServiceName } from '@unstoppabledomains/resolution';
 import type { EthersProvider } from '../types';
 import { CNS_RESOLVER_ABI } from './constants';

--- a/umbra-js/src/utils/utils.ts
+++ b/umbra-js/src/utils/utils.ts
@@ -19,7 +19,7 @@ import {
   StaticJsonRpcProvider,
   UnsignedTransaction,
 } from '../ethers';
-import { Point, Signature, recoverPublicKey } from 'noble-secp256k1';
+import { Point, Signature, recoverPublicKey } from '@noble/secp256k1';
 import { ens, cns } from '..';
 import { default as Resolution } from '@unstoppabledomains/resolution';
 import { StealthKeyRegistry } from '../classes/StealthKeyRegistry';

--- a/umbra-js/src/utils/utils.ts
+++ b/umbra-js/src/utils/utils.ts
@@ -250,7 +250,7 @@ export function assertValidPoint(point: string) {
 }
 
 /**
- * @notice Throws if provided private key is not valid
+ * @notice Throws if provided private key is not valid.
  * @param point Private key as hex string
  */
 export function assertValidPrivateKey(key: string) {
@@ -263,7 +263,7 @@ export function assertValidPrivateKey(key: string) {
 }
 
 /**
- * @notice Returns the public keys associated with the provided name, using the legacy lookup approach
+ * @notice Returns the public keys associated with the provided name, using the legacy lookup approach.
  * @param name Name or domain to test
  * @param provider ethers provider instance
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3728,6 +3728,11 @@
   resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.6.3.tgz#7eed12d9f4404b416999d0c87686836c4c5c9b94"
   integrity sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==
 
+"@noble/secp256k1@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
+  integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -16517,11 +16522,6 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-noble-secp256k1@^1.2.5:
-  version "1.2.14"
-  resolved "https://registry.yarnpkg.com/noble-secp256k1/-/noble-secp256k1-1.2.14.tgz#39429c941d51211ca40161569cee03e61d72599e"
-  integrity sha512-GSCXyoZBUaaPwVWdYncMEmzlSUjF9J/YeEHpklYJCyg8wPuJP3NzDx0BkiwArzINkdX2HJHvUJhL6vVWPOQQcg==
-
 node-addon-api@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
@@ -23062,10 +23062,20 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-y18n@^3.2.1, y18n@^4.0.0, y18n@^4.0.1, y18n@^5.0.5:
+y18n@^3.2.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.2.tgz#85c901bd6470ce71fc4bb723ad209b70f7f28696"
+  integrity sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==
+
+y18n@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
 yaeti@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
Closes #436

Only changes the internals of umbra-js methods to accommodate the changes to the noble API. 

At first I started making lots of changes to tighten up our interfaces to be more strongly typed than just `string` everywhere by using the noble types. This ends up snowballing into a massive change by changing interfaces to lots of functions, which would also require frontend changes. That didn't seem necessary right now, so I bailed on that and kept it simple

Because no interfaces have changed and all tests pass I did not do any frontend testing, but perhaps we should to be safe.