### PR TITLE
feat: show token balances on send page dropdown

### DIFF
--- a/frontend/src/components/BaseSelect.vue
+++ b/frontend/src/components/BaseSelect.vue
@@ -39,8 +39,12 @@
             <img class="horizontal-center" :src="scope.opt.logoURI" style="height: 1.5rem" />
           </q-item-section>
           <q-item-section>
-            <!-- eslint-disable-next-line vue/no-v-text-v-html-on-component -->
-            <q-item-label v-html="scope.opt[optionLabel]" />
+            <q-item-label>{{ scope.opt[optionLabel] }}</q-item-label>
+          </q-item-section>
+          <q-item-section v-if="tokenBalances">
+            <q-item-label class="text-right">
+              {{ humanizeTokenAmount(tokenBalances[scope.opt.address], scope.opt) }}
+            </q-item-label>
           </q-item-section>
         </q-item>
       </template>
@@ -50,6 +54,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { humanizeTokenAmount } from 'src/utils/utils';
 
 export default defineComponent({
   name: 'BaseSelect',
@@ -145,12 +150,19 @@ export default defineComponent({
         return true;
       },
     },
+
+    // If provided, assumes the list given is a token list and shows token balances in the dropdown.
+    tokenBalances: {
+      type: Object,
+      required: false,
+    },
   },
 
   data() {
     return {
       content: this.modelValue,
       hintString: '',
+      humanizeTokenAmount,
     };
   },
 

--- a/frontend/src/pages/AccountSend.vue
+++ b/frontend/src/pages/AccountSend.vue
@@ -137,6 +137,7 @@
         :options="tokenList"
         option-label="symbol"
         ref="tokenBaseSelectRef"
+        :token-balances="balances"
       />
 
       <!-- Amount -->
@@ -537,6 +538,7 @@ function useSendForm() {
     acknowledgeSendRisk,
     advancedAcknowledged,
     advancedMode,
+    balances,
     chainId,
     currentChain,
     humanAmount,


### PR DESCRIPTION
Closes #294 

Style loosely mirrors what Uniswap does to show balances

<img src="https://user-images.githubusercontent.com/17163988/217273038-0fb37685-508c-4fc6-be96-dcdc1661dcad.png" width=400 />

<img width="400" alt="image" src="https://user-images.githubusercontent.com/17163988/217273075-c00428ce-7696-470e-99bb-5a8f338df250.png">
