### PR TITLE
Warn if confusable characters are used in ENS name

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "ethers": "5.7.2",
     "localforage": "^1.10.0",
     "quasar": "2.10.2",
+    "unicode-confusables": "0.1.1",
     "vue-i18n": "^9.2.2",
     "vue-router": "4.1.6",
     "vue": "3.2.45",

--- a/frontend/src/shims-vue.d.ts
+++ b/frontend/src/shims-vue.d.ts
@@ -8,3 +8,8 @@ declare module '*.vue' {
 declare module '@metamask/jazzicon' {
   export default function (diameter: number, seed: number): HTMLElement;
 }
+
+// For the unicode-confusables package
+declare module 'unicode-confusables' {
+  export function isConfusing(input: string): boolean;
+}

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -1,4 +1,5 @@
 import { BigNumber, computeAddress, isHexString, isAddress } from 'src/utils/ethers';
+import { isConfusing } from 'unicode-confusables';
 
 export const assertValidAddress = (address: string, errorMsg?: string) => {
   if (!address.startsWith('0x') || !isAddress(address)) {
@@ -29,5 +30,12 @@ export const assertValidEncryptionCount = (count: BigNumber, errorMsg?: string) 
 export const assertValidHexString = (hex: string, length: number, errorMsg?: string) => {
   if (!isHexString(hex, length)) {
     throw new Error(errorMsg || 'Invalid hex string was provided');
+  }
+};
+
+export const assertNoConfusables = (name: string, errorMsg?: string) => {
+  const hasConfusables = isConfusing(name);
+  if (hasConfusables) {
+    throw new Error(errorMsg || 'Name contains confusables');
   }
 };

--- a/frontend/test/validation.test.ts
+++ b/frontend/test/validation.test.ts
@@ -1,0 +1,18 @@
+import { assertNoConfusables } from '../src/utils/validation';
+
+describe('assertNoConfusables', () => {
+  it('Pass in name with a confusable', () => {
+    const x = () => assertNoConfusables('‌.eth');
+    expect(x).toThrow('Name contains confusables');
+  });
+
+  it('Pass in name with a confusable and a custom error message', () => {
+    const x = () => assertNoConfusables('‌.eth', 'Custom error');
+    expect(x).toThrow('Custom error');
+  });
+
+  it('Pass in a valid name', () => {
+    const x = () => assertNoConfusables('hi.eth', 'Custom error');
+    expect(x).not.toThrow();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -21013,6 +21013,11 @@ unicode-canonical-property-names-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz#301acdc525631670d39f6146e0e77ff6bbdebddc"
   integrity sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==
 
+unicode-confusables@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/unicode-confusables/-/unicode-confusables-0.1.1.tgz#17f14e8dc53ff81c12e92fd86e836ebdf14ea0c2"
+  integrity sha512-XTPBWmT88BDpXz9NycWk4KxDn+/AJmJYYaYBwuIH9119sopwk2E9GxU9azc+JNbhEsfiPul78DGocEihCp6MFQ==
+
 unicode-match-property-ecmascript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz#54fd16e0ecb167cf04cf1f756bdcc92eba7976c3"


### PR DESCRIPTION
#### Description

- Check if the ENS name contains a confusable character and raise a warning if there is and there are no errors.

Closes #154 

![Screenshot from 2023-05-30 12-23-45](https://github.com/ScopeLift/umbra-protocol/assets/12705146/4018a315-76a3-42a7-85b5-aa487a3a6b0a)
