### PR TITLE
Add new network to wallet fix Closes #537

### DIFF
--- a/frontend/src/store/wallet.ts
+++ b/frontend/src/store/wallet.ts
@@ -414,10 +414,13 @@ export default function useWalletStore() {
         try {
           // Extract EIP-3085 incompatible fields
           const { nativeCurrency, logoURI, iconUrls, blockExplorerUrls, rpcUrls, ...chainIdAndName } = { ...chain };
+          if (!blockExplorerUrls) {
+            throw new Error('blockExplorerUrls is missing');
+          }
           const { address, logoURI: currencyLogoURI, ...nativeCurrencySummary } = nativeCurrency;
           const eip3085Chain = {
             nativeCurrency: nativeCurrencySummary,
-            blockExplorerUrls: [...(blockExplorerUrls as string[])],
+            blockExplorerUrls: [...blockExplorerUrls],
             rpcUrls: [...rpcUrls],
             ...chainIdAndName,
           };

--- a/frontend/src/store/wallet.ts
+++ b/frontend/src/store/wallet.ts
@@ -412,8 +412,15 @@ export default function useWalletStore() {
       // This error code indicates that the chain has not been added to MetaMask.
       if (code === 4902) {
         try {
-          const eip3085Chain = <Chain>{ ...chain }; // without casting to any, TS errors on `delete` since we're deleting a required property
-          delete eip3085Chain.logoURI; // if you don't remove extraneous fields, adding the chain will error
+          // Extract EIP-3085 incompatible fields
+          const { nativeCurrency, logoURI, iconUrls, blockExplorerUrls, rpcUrls, ...chainIdAndName } = { ...chain };
+          const { address, logoURI: currencyLogoURI, ...nativeCurrencySummary } = nativeCurrency;
+          const eip3085Chain = {
+            nativeCurrency: nativeCurrencySummary,
+            blockExplorerUrls: [...(blockExplorerUrls as string[])],
+            rpcUrls: [...rpcUrls],
+            ...chainIdAndName,
+          };
           await provider.value?.send('wallet_addEthereumChain', [eip3085Chain]);
         } catch (addError) {
           console.log(addError);


### PR DESCRIPTION
- Removed `iconUrls` from `eip3085Chain`. There are a number of open issues related to this on Metamask's [repo](https://github.com/search?q=repo%3AMetaMask%2Fmetamask-extension+addEthereumChain&type=issues&p=1)
- Removed `address` and `logoURI` from `nativeCurrency` to be EIP3085 compatible.
- Spread `blockExplorerUrls` and `rpcUrls` from proxy arrays to actually arrays before calling `wallet_addEthereumChain`

Now users will be prompted to add the new network to their wallet when they select it from the network dropdown menu.