### PR TITLE
Use ens normalize instead of confusable

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
+    "@adraffy/ens-normalize": "1.9.2",
     "@ledgerhq/devices": "^7.0.5",
     "@metamask/jazzicon": "^2.0.0",
     "@quasar/extras": "^1.15.8",
@@ -34,7 +35,6 @@
     "ethers": "5.7.2",
     "localforage": "^1.10.0",
     "quasar": "2.10.2",
-    "unicode-confusables": "0.1.1",
     "vue-i18n": "^9.2.2",
     "vue-router": "4.1.6",
     "vue": "3.2.45",

--- a/frontend/src/pages/AccountSend.vue
+++ b/frontend/src/pages/AccountSend.vue
@@ -515,7 +515,7 @@ import { Provider, TokenInfoExtended, supportedChains } from 'components/models'
 import { ERC20_ABI } from 'src/utils/constants';
 import { toAddress } from 'src/utils/address';
 import { storeSend, StoreSendArgs } from 'src/utils/account-send';
-import { assertNoConfusables } from 'src/utils/validation';
+import { assertValidEnsName } from 'src/utils/validation';
 
 interface BatchSendData {
   id: number;
@@ -1203,10 +1203,7 @@ function useSendForm() {
     const recipientIdString = recipientId.value || '';
     try {
       if (recipientIdString && recipientIdString.endsWith('eth')) {
-        assertNoConfusables(
-          recipientIdString,
-          'We have detected a confusable character in the ENS name. Check the ENS name to avoid a potential scam.'
-        );
+        assertValidEnsName(recipientIdString);
       }
       recipientIdWarning.value = undefined;
     } catch (e) {

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -37,6 +37,10 @@ export const assertValidEnsName = (name: string) => {
   try {
     ens_normalize(name);
   } catch (err) {
+    // A couple example error messages from ens-normalize:
+    // ‌hi.eth - Invalid label "{200C}hi"‎: disallowed character: {200C}
+    // aα.eth - Invalid label "aα"‎: illegal mixture: Latin + Greek "α"‎ {3B1}
+    console.log((err as Error)?.message);
     throw new Error(
       `We detected a${
         (err as Error)?.message.split(':')[1]

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -42,9 +42,10 @@ export const assertValidEnsName = (name: string) => {
     // aα.eth - Invalid label "aα"‎: illegal mixture: Latin + Greek "α"‎ {3B1}
     console.log((err as Error)?.message);
     throw new Error(
-      `We detected a${
-        (err as Error)?.message.split(':')[1]
-      } in the ENS name. Check the ENS name in order to avoid a potential scam.`
+      `The given ENS name is invalid due to: ${(err as Error)?.message
+        .split(':')
+        .slice(1)
+        .join('')} in the ENS name. Check the ENS name in order to avoid a potential scam.`
     );
   }
 };

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -1,5 +1,5 @@
 import { BigNumber, computeAddress, isHexString, isAddress } from 'src/utils/ethers';
-import { isConfusing } from 'unicode-confusables';
+import { ens_normalize } from '@adraffy/ens-normalize';
 
 export const assertValidAddress = (address: string, errorMsg?: string) => {
   if (!address.startsWith('0x') || !isAddress(address)) {
@@ -33,9 +33,14 @@ export const assertValidHexString = (hex: string, length: number, errorMsg?: str
   }
 };
 
-export const assertNoConfusables = (name: string, errorMsg?: string) => {
-  const hasConfusables = isConfusing(name);
-  if (hasConfusables) {
-    throw new Error(errorMsg || 'Name contains confusables');
+export const assertValidEnsName = (name: string) => {
+  try {
+    ens_normalize(name);
+  } catch (err) {
+    throw new Error(
+      `We detected a${
+        (err as Error)?.message.split(':')[1]
+      } in the ENS name. Check the ENS name in order to avoid a potential scam.`
+    );
   }
 };

--- a/frontend/test/validation.test.ts
+++ b/frontend/test/validation.test.ts
@@ -1,18 +1,15 @@
-import { assertNoConfusables } from '../src/utils/validation';
+import { assertValidEnsName } from '../src/utils/validation';
 
 describe('assertNoConfusables', () => {
   it('Pass in name with a confusable', () => {
-    const x = () => assertNoConfusables('‌.eth');
-    expect(x).toThrow('Name contains confusables');
-  });
-
-  it('Pass in name with a confusable and a custom error message', () => {
-    const x = () => assertNoConfusables('‌.eth', 'Custom error');
-    expect(x).toThrow('Custom error');
+    const x = () => assertValidEnsName('‌.eth');
+    expect(x).toThrow(
+      'We detected a disallowed character in the ENS name. Check the ENS name in order to avoid a potential scam.'
+    );
   });
 
   it('Pass in a valid name', () => {
-    const x = () => assertNoConfusables('hi.eth', 'Custom error');
+    const x = () => assertValidEnsName('hi.eth');
     expect(x).not.toThrow();
   });
 });

--- a/frontend/test/validation.test.ts
+++ b/frontend/test/validation.test.ts
@@ -4,7 +4,7 @@ describe('assertNoConfusables', () => {
   it('Pass in name with a confusable', () => {
     const x = () => assertValidEnsName('‌.eth');
     expect(x).toThrow(
-      'We detected a disallowed character in the ENS name. Check the ENS name in order to avoid a potential scam.'
+      'The given ENS name is invalid due to:  disallowed character {200C} in the ENS name. Check the ENS name in order to avoid a potential scam.'
     );
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adraffy/ens-normalize@1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz#60111a5d9db45b2e5cbb6231b0bb8d97e8659316"
+  integrity sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==
+
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -21729,11 +21734,6 @@ unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz#301acdc525631670d39f6146e0e77ff6bbdebddc"
   integrity sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==
-
-unicode-confusables@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/unicode-confusables/-/unicode-confusables-0.1.1.tgz#17f14e8dc53ff81c12e92fd86e836ebdf14ea0c2"
-  integrity sha512-XTPBWmT88BDpXz9NycWk4KxDn+/AJmJYYaYBwuIH9119sopwk2E9GxU9azc+JNbhEsfiPul78DGocEihCp6MFQ==
 
 unicode-match-property-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### Description

- Use ens normalize to detect confusable, illegal characters and illegal mixtures of unicode characters. This should conform better with ENS compared to `unicode-confusables`.

Closes #552 