### PR TITLE
Fix Gnosis scanning error -- Block range too wide

### DIFF
--- a/umbra-js/src/classes/Umbra.ts
+++ b/umbra-js/src/classes/Umbra.ts
@@ -410,8 +410,7 @@ export class Umbra {
   ): Promise<AnnouncementDetail[]> {
     const registeredBlockNumber = await getBlockNumberUserRegistered(address, Signer.provider);
     // Get start and end blocks to scan events for
-    const startBlock = overrides.startBlock || registeredBlockNumber;
-    if (!startBlock) return [];
+    const startBlock = overrides.startBlock || registeredBlockNumber || this.chainConfig.startBlock;
     const endBlock = overrides.endBlock || 'latest';
     return this.fetchAllAnnouncements({ startBlock, endBlock });
   }

--- a/umbra-js/src/utils/utils.ts
+++ b/umbra-js/src/utils/utils.ts
@@ -245,9 +245,13 @@ export async function getBlockNumberUserRegistered(address: string, provider: St
   address = getAddress(address); // address input validation
   const registry = new StealthKeyRegistry(provider);
   const filter = registry._registry.filters.StealthKeyChanged(address, null, null, null, null);
-  const stealthKeyLogs = await registry._registry.queryFilter(filter);
-  const registryBlock = stealthKeyLogs[0]?.blockNumber || undefined;
-  return registryBlock;
+  try {
+    const stealthKeyLogs = await registry._registry.queryFilter(filter);
+    const registryBlock = stealthKeyLogs[0]?.blockNumber || undefined;
+    return registryBlock;
+  } catch {
+    return undefined;
+  }
 }
 
 /**


### PR DESCRIPTION
Fix for receive page scanning on Gnosis Chain, which currently throws `Internal JSON-RPC error`

![Screenshot 2023-07-13 at 3 49 08 PM](https://github.com/ScopeLift/umbra-protocol/assets/61768337/e81ec3b9-a571-4444-b2d1-6699f6f880ab)

Regression: 
Filtering announcements no longer returns an empty array when the startBlock is `undefined` instead it reverts back to `chainConfig` default `startblock`. Will create an issue to handle this elsewhere using `isAccountSetup` from `walletStore`. See https://github.com/ScopeLift/umbra-protocol/issues/569