### PR TITLE
Fix #558 CI

### DIFF
--- a/umbra-js/src/classes/Umbra.ts
+++ b/umbra-js/src/classes/Umbra.ts
@@ -393,8 +393,9 @@ export class Umbra {
       } catch (err) {
         yield await this.fetchAllAnnouncementFromLogs(startBlock, endBlock);
       }
+    } else {
+      yield await this.fetchAllAnnouncementFromLogs(startBlock, endBlock);
     }
-    yield await this.fetchAllAnnouncementFromLogs(startBlock, endBlock);
   }
 
   /**

--- a/umbra-js/src/classes/Umbra.ts
+++ b/umbra-js/src/classes/Umbra.ts
@@ -391,9 +391,10 @@ export class Umbra {
           yield details;
         }
       } catch (err) {
-        return this.fetchAllAnnouncementFromLogs(startBlock, endBlock);
+        yield await this.fetchAllAnnouncementFromLogs(startBlock, endBlock);
       }
     }
+    yield await this.fetchAllAnnouncementFromLogs(startBlock, endBlock);
   }
 
   /**
@@ -517,8 +518,8 @@ export class Umbra {
    */
   async scan(spendingPublicKey: string, viewingPrivateKey: string, overrides: ScanOverrides = {}) {
     const userAnnouncements: UserAnnouncement[] = [];
-    for await (const ann of this.fetchAllAnnouncements(overrides)) {
-      for (const announcement of ann) {
+    for await (const announcementsBatch of this.fetchAllAnnouncements(overrides)) {
+      for (const announcement of announcementsBatch) {
         const { amount, from, receiver, timestamp, token: tokenAddr, txHash } = announcement;
         const { isForUser, randomNumber } = Umbra.isAnnouncementForUser(
           spendingPublicKey,


### PR DESCRIPTION
Fixes [CI failures](https://github.com/ScopeLift/umbra-protocol/actions/runs/5556669269/jobs/10149474025?pr=558) in #573 #558 
**Issue**: Because `typeof window` is undefined during the test, the `try` `catch` block of code is skipped, resulting in an empty `userAnnouncements` array being returned. Therefore, all tests involving the `Umbra.scan` function was failing the CI.

**Solution**: If conditions for the `try` `catch` block aren't met, yield announcements from logs:
```
397    yield await this.fetchAllAnnouncementFromLogs(startBlock, endBlock);
```
Because `fetchAllAnnouncements` is now a AsyncGenerator function that `yields` announcements as they are fetched, also update the previous call to `fetchAllAnnouncementFromLogs` to
```
394    yield await this.fetchAllAnnouncementFromLogs(startBlock, endBlock);
```

Also update variable name from ambiguous `ann` to `announcementsBatch`