### PR TITLE
Use try catch block for address lookups Closes #582

### DIFF
--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -100,7 +100,7 @@
                         ? formatNameOrAddress(props.row.formattedFrom)
                         : formatNameOrAddress(props.row.from)
                     }}</span>
-                    <loading-spinner v-if="!props.row.formattedFrom" size="1rem" customClass="q-ml-sm" />
+                    <loading-spinner v-if="isLoading" size="1rem" customClass="q-ml-sm" />
                     <q-icon v-else color="primary" class="q-ml-sm" name="far fa-copy" />
                   </div>
                 </div>
@@ -247,7 +247,7 @@
                       ? formatNameOrAddress(props.row.formattedFrom)
                       : formatNameOrAddress(props.row.from)
                   }}</span>
-                  <loading-spinner v-if="!props.row.formattedFrom" size="1rem" customClass="q-ml-sm" />
+                  <loading-spinner v-if="isLoading" size="1rem" customClass="q-ml-sm" />
                   <q-icon v-else class="copy-icon" name="far fa-copy" right />
                 </div>
               </div>
@@ -526,7 +526,12 @@ function useReceivedFundsTable(userAnnouncements: Ref<UserAnnouncement[]>, spend
     formattedAnnouncements.value = [...formattedAnnouncements.value, ...newAnnouncements];
     // Format addresses to use ENS, CNS, or formatted address
     const fromAddresses = announcements.map((announcement) => announcement.from);
-    const formattedAddresses = await lookupOrReturnAddresses(fromAddresses, MAINNET_PROVIDER as Web3Provider);
+    let formattedAddresses: string[] = [];
+    try {
+      formattedAddresses = await lookupOrReturnAddresses(fromAddresses, MAINNET_PROVIDER as Web3Provider);
+    } catch (err) {
+      console.error(err);
+    }
     formattedAnnouncements.value.forEach((announcement, index) => {
       if (newAnnouncements.some((newAnnouncement) => newAnnouncement.txHash === announcement.txHash)) {
         announcement.formattedFrom = formattedAddresses[index];


### PR DESCRIPTION
Without a working mainnet RPC url `lookupOrReturnAddresses` was throwing an error causing the table to be stuck at a loading state with spinning icons. This PR adds a `try-catch` block to handle the error.