### PR TITLE
Remove potential ENS lookup error message overlap on batch sends.

### DIFF
--- a/frontend/src/pages/AccountSend.vue
+++ b/frontend/src/pages/AccountSend.vue
@@ -879,7 +879,14 @@ function useSendForm() {
         }
       }
       const toSentenceCase = (str: string) => str[0].toUpperCase() + str.slice(1);
-      if (e instanceof Error && e.message) return toSentenceCase(e.message);
+      if (e instanceof Error && e.message) {
+        if (e.message.includes('Please verify the provided name or address')) {
+          e.message =
+            'Please verify the provided name or address is correct. ' +
+            'If providing an ENS name, ensure it is registered, and has a valid address record.';
+        }
+        return toSentenceCase(e.message);
+      }
       if ((e as { reason: string }).reason) return toSentenceCase((e as { reason: string }).reason);
       return JSON.stringify(e);
     }


### PR DESCRIPTION
Resolves #646 

Remove offending Recipient ID string from error message for more consistent layout.

Because the existing ENS lookup error message contains the variable length Recipient ID, when it is long is can cause the error message to sometime pop down over either the confusables warning message or the next batch send label. The variable length of the error string popped down by the base-input component makes layout calculations problematic.
Made the change to substitute a fixed length error message here in the frontend rather than in UmbraJS to ensure users of UmbraJS aren't affected by any messaging changes the thrown error. 

Dependance on a specific string from UmbraJS is somewhat brittle, if there's a better way to accomplish, please mention in review.