### PR TITLE
Detect Umbra relayer/API version change and force reload

### DIFF
--- a/frontend/src/components/AccountReceiveTable.vue
+++ b/frontend/src/components/AccountReceiveTable.vue
@@ -512,7 +512,7 @@ function useReceivedFundsTable(userAnnouncements: Ref<UserAnnouncement[]>, spend
   const getFeeEstimate = async (tokenAddress: string) => {
     if (isNativeToken(tokenAddress)) {
       // no fee for native token
-      activeFee.value = { fee: '0', token: NATIVE_TOKEN.value };
+      activeFee.value = { umbraApiVersion: { major: 0, minor: 0, patch: 0 }, fee: '0', token: NATIVE_TOKEN.value };
       return;
     }
     isFeeLoading.value = true;

--- a/frontend/src/components/models.ts
+++ b/frontend/src/components/models.ts
@@ -170,16 +170,23 @@ export interface CnsQueryResponse {
 
 // Relayer types
 export type ApiError = { error: string };
+export interface UmbraApiVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
 export interface TokenInfoExtended extends TokenInfo {
   minSendAmount: string;
 }
 // Omit the TokenList.tokens type so we can override it with our own.
 export interface TokenListSuccessResponse extends Omit<TokenList, 'tokens'> {
+  umbraApiVersion: UmbraApiVersion;
   nativeTokenMinSendAmount: string;
   tokens: TokenInfoExtended[];
 }
 export type TokenListResponse = TokenListSuccessResponse | ApiError;
-export type FeeEstimate = { fee: string; token: TokenInfo };
+export type FeeEstimate = { umbraApiVersion: UmbraApiVersion; fee: string; token: TokenInfo };
 export type FeeEstimateResponse = FeeEstimate | ApiError;
 export type WithdrawalInputs = {
   stealthAddr: string;
@@ -187,7 +194,7 @@ export type WithdrawalInputs = {
   signature: string;
   sponsorFee: string;
 };
-export type RelayResponse = { relayTransactionHash: string } | ApiError;
+export type RelayResponse = { umbraApiVersion: UmbraApiVersion; relayTransactionHash: string } | ApiError;
 
 export type SendTableMetadataRow = {
   dateSent: string;

--- a/frontend/src/store/settings.ts
+++ b/frontend/src/store/settings.ts
@@ -2,7 +2,7 @@ import { computed, onMounted, ref } from 'vue';
 import { Dark, LocalStorage } from 'quasar';
 import { isHexString } from 'src/utils/ethers';
 import { i18n } from '../boot/i18n';
-import { Language } from '../components/models';
+import { Language, UmbraApiVersion } from '../components/models';
 
 // Local storage key names
 const settings = {
@@ -11,6 +11,7 @@ const settings = {
   lastWallet: 'last-wallet',
   language: 'language',
   sendHistorySave: 'send-history-save',
+  UmbraApiVersion: 'umbra-api-version',
 };
 
 // Shared state between instances
@@ -119,6 +120,23 @@ export default function useSettingsStore() {
     scanPrivateKey.value = undefined;
   }
 
+  function getUmbraApiVersion(): UmbraApiVersion | null {
+    const storedVersion = LocalStorage.getItem(settings.UmbraApiVersion);
+    if (storedVersion) {
+      return storedVersion as UmbraApiVersion;
+    } else {
+      return null;
+    }
+  }
+
+  function setUmbraApiVersion(version: UmbraApiVersion) {
+    LocalStorage.set(settings.UmbraApiVersion, version);
+  }
+
+  function clearUmbraApiVersion() {
+    LocalStorage.remove(settings.UmbraApiVersion);
+  }
+
   return {
     toggleDarkMode,
     toggleAdvancedMode,
@@ -137,5 +155,8 @@ export default function useSettingsStore() {
     endBlock: computed(() => endBlock.value),
     scanPrivateKey: computed(() => scanPrivateKey.value),
     lastWallet: computed(() => lastWallet.value),
+    getUmbraApiVersion,
+    setUmbraApiVersion,
+    clearUmbraApiVersion,
   };
 }

--- a/frontend/src/utils/umbra-api.ts
+++ b/frontend/src/utils/umbra-api.ts
@@ -40,7 +40,7 @@ export class UmbraApi {
       if (apiVersionFromSettings.major != version.major || apiVersionFromSettings.minor != version.minor) {
         console.log('UmbraAPI: version mismatch, clearing settings and going to force a page reload');
         clearUmbraApiVersion();
-        alert('UmbraAPI: version mismatch, clearing settings and going to force a page reload');
+        alert('UmbraAPI: version outdated, please reload the page');
         window.location.reload();
       }
     }

--- a/frontend/src/utils/umbra-api.ts
+++ b/frontend/src/utils/umbra-api.ts
@@ -28,7 +28,7 @@ export class UmbraApi {
   ) {}
 
   static checkUmbraApiVersion(version: UmbraApiVersion) {
-    const apiVersionFromSettings: UmbraApiVersion | null = getUmbraApiVersion();
+    const apiVersionFromSettings = getUmbraApiVersion();
     if (!apiVersionFromSettings) {
       console.log(`UmbraAPI: no saved version setting, using backend value: ${version.major}.${version.minor}`);
       setUmbraApiVersion(version);

--- a/frontend/src/utils/umbra-api.ts
+++ b/frontend/src/utils/umbra-api.ts
@@ -10,16 +10,41 @@ import {
   RelayResponse,
   TokenListResponse,
   WithdrawalInputs,
+  UmbraApiVersion,
 } from 'components/models';
 import { jsonFetch } from 'src/utils/utils';
 
+import useSettingsStore from 'src/store/settings';
+
+const { getUmbraApiVersion, setUmbraApiVersion, clearUmbraApiVersion } = useSettingsStore();
+
 export class UmbraApi {
   static baseUrl = 'https://mainnet.api.umbra.cash'; // works for all networks
+  // static baseUrl = 'http://localhost:3000';  // use this for testing with a local Umbra API
   constructor(
     readonly tokens: TokenInfoExtended[],
     readonly chainId: number,
     readonly nativeTokenMinSendAmount: string | undefined
   ) {}
+
+  static checkUmbraApiVersion(version: UmbraApiVersion) {
+    const apiVersionFromSettings: UmbraApiVersion | null = getUmbraApiVersion();
+    if (!apiVersionFromSettings) {
+      console.log(`UmbraAPI: no saved version setting, using backend value: ${version.major}.${version.minor}`);
+      setUmbraApiVersion(version);
+    } else {
+      console.log(`UmbraAPI: major.minor version fetched from backend: ${version.major}.${version.minor}`);
+      console.log(
+        `UmbraAPI: major.minor version fetched from setting: ${apiVersionFromSettings.major}.${apiVersionFromSettings.minor}`
+      );
+      if (apiVersionFromSettings.major != version.major || apiVersionFromSettings.minor != version.minor) {
+        console.log('UmbraAPI: version mismatch, clearing settings and going to force a page reload');
+        clearUmbraApiVersion();
+        alert('UmbraAPI: version mismatch, clearing settings and going to force a page reload');
+        window.location.reload();
+      }
+    }
+  }
 
   static async create(provider: Provider | StaticJsonRpcProvider) {
     // Get API URL based on chain ID
@@ -37,6 +62,7 @@ export class UmbraApi {
     } else {
       tokens = data.tokens;
       nativeMinSend = data.nativeTokenMinSendAmount;
+      UmbraApi.checkUmbraApiVersion(data.umbraApiVersion);
     }
 
     // Return instance, using an empty array of tokens if we could not fetch them from
@@ -48,6 +74,7 @@ export class UmbraApi {
     const response = await fetch(`${UmbraApi.baseUrl}/tokens/${tokenAddress}/estimate?chainId=${this.chainId}`);
     const data = (await response.json()) as FeeEstimateResponse;
     if ('error' in data) throw new Error(`Could not estimate fee: ${data.error}`);
+    UmbraApi.checkUmbraApiVersion(data.umbraApiVersion);
     return data;
   }
 
@@ -58,12 +85,16 @@ export class UmbraApi {
     const response = await fetch(url, { method: 'POST', body, headers });
     const data = (await response.json()) as RelayResponse;
     if ('error' in data) throw new Error(`Could not relay withdraw: ${data.error}`);
+    UmbraApi.checkUmbraApiVersion(data.umbraApiVersion);
     return data;
   }
 
   static async isGitcoinContributor(address: string) {
-    return (await jsonFetch(`${this.baseUrl}/addresses/${address}/is-gitcoin-contributor`)) as {
+    const response = (await jsonFetch(`${this.baseUrl}/addresses/${address}/is-gitcoin-contributor`)) as {
+      umbraApiVersion: UmbraApiVersion;
       isContributor: boolean;
     };
+    UmbraApi.checkUmbraApiVersion(response.umbraApiVersion);
+    return response;
   }
 }

--- a/frontend/src/utils/umbra-api.ts
+++ b/frontend/src/utils/umbra-api.ts
@@ -19,8 +19,8 @@ import useSettingsStore from 'src/store/settings';
 const { getUmbraApiVersion, setUmbraApiVersion, clearUmbraApiVersion } = useSettingsStore();
 
 export class UmbraApi {
+  // use 'http://localhost:3000' for baseUrl value for testing with a local Umbra API
   static baseUrl = 'https://mainnet.api.umbra.cash'; // works for all networks
-  // static baseUrl = 'http://localhost:3000';  // use this for testing with a local Umbra API
   constructor(
     readonly tokens: TokenInfoExtended[],
     readonly chainId: number,


### PR DESCRIPTION
Resolves #309 

Added most recently obtained version of Umbra relayer/API to local storage..

At startup, on creation of Umbra relayer/API.. and on every interaction between the front-end and the API.. the API version is returned in the API's response to the front-end, and the version and local storage are used in the following way:

1. Attempt to read the most recently saved API version from local storage.
2. If the version does not exist in local storage, save the most recently received version from the API to local storage.
3. If the version does exist in local storage, compare it to the version received from the API.. if the major/minor numbers differ, the following actions are taken:
   a. The saved API version in local storage is cleared.
   b. The user is alerted.
   c. The user is forced to reload the front-end web app.
   d. On that reload, because the saved version in local storage is not present, the save described in step 2 above will occur.

Currently the alert to the user is just that.. a javascript "alert".. but can probably be done in a more "Vue-centric" way.