### PR TITLE
Checkpoint receive scans to subgraph head block

### DIFF
--- a/frontend/src/pages/AccountReceive.vue
+++ b/frontend/src/pages/AccountReceive.vue
@@ -391,6 +391,95 @@ function useScan() {
     return provider.getBlock('latest');
   }
 
+  function getPonderNetworkName(chainId: number): string | null {
+    switch (chainId) {
+      case 1:
+        return 'mainnet';
+      case 10:
+        return 'optimism';
+      case 137:
+        return 'polygon';
+      case 8453:
+        return 'base';
+      case 42161:
+        return 'arbitrumOne';
+      case 11155111:
+        return 'sepolia';
+      default:
+        return null;
+    }
+  }
+
+  async function getSubgraphHeadBlockNumber(chainId: number, subgraphUrl: string): Promise<number> {
+    const headers = { 'Content-Type': 'application/json' };
+    const ponderNetwork = getPonderNetworkName(chainId);
+
+    if (ponderNetwork) {
+      const ponderResponse = await fetch(subgraphUrl, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          query: `{
+            _meta {
+              status
+            }
+          }`,
+        }),
+      });
+
+      if (!ponderResponse.ok) throw new Error(`Subgraph head request failed with status ${ponderResponse.status}`);
+
+      const ponderPayload = (await ponderResponse.json()) as {
+        data?: { _meta?: { status?: Record<string, { block?: { number?: number } }> } };
+        errors?: Array<{ message: string }>;
+      };
+
+      const statusError = ponderPayload.errors?.find((error) => error.message.includes('Cannot query field "status"'));
+      if (!statusError && ponderPayload.errors?.length) {
+        throw new Error(ponderPayload.errors.map((error) => error.message).join('; '));
+      }
+
+      const ponderHead = ponderPayload.data?._meta?.status?.[ponderNetwork]?.block?.number;
+      if (typeof ponderHead === 'number' && Number.isFinite(ponderHead)) {
+        return ponderHead;
+      }
+    }
+
+    const legacyResponse = await fetch(subgraphUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        query: `{
+          _meta {
+            block {
+              number
+            }
+          }
+        }`,
+      }),
+    });
+
+    if (!legacyResponse.ok) throw new Error(`Legacy subgraph head request failed with status ${legacyResponse.status}`);
+
+    const legacyPayload = (await legacyResponse.json()) as {
+      data?: { _meta?: { block?: { number?: number | string } } };
+      errors?: Array<{ message: string }>;
+    };
+    if (legacyPayload.errors?.length) {
+      throw new Error(legacyPayload.errors.map((error) => error.message).join('; '));
+    }
+
+    const legacyHead = legacyPayload.data?._meta?.block?.number;
+    if (typeof legacyHead === 'number' && Number.isFinite(legacyHead)) {
+      return legacyHead;
+    }
+    if (typeof legacyHead === 'string' && legacyHead.length > 0) {
+      return Number(legacyHead);
+    }
+
+    throw new Error(`Missing subgraph head block for chain ${chainId}`);
+  }
+
   async function scan() {
     // Reset paused state
     paused.value = false;
@@ -482,6 +571,20 @@ function useScan() {
         const latestBlock: Block = await getLastBlock(provider.value!);
         mostRecentBlockNumber.value = latestBlock.number;
         mostRecentBlockTimestamp.value = latestBlock.timestamp;
+        let nextStartBlock = latestBlock.number;
+        if (umbra.value.chainConfig.subgraphUrl) {
+          try {
+            nextStartBlock = await getSubgraphHeadBlockNumber(
+              umbra.value.chainConfig.chainId,
+              umbra.value.chainConfig.subgraphUrl
+            );
+          } catch (error) {
+            const fallbackBlock =
+              startBlockLocal.value ?? mostRecentAnnouncementBlockNumber.value ?? getRegisteredBlockNumber();
+            if (fallbackBlock) nextStartBlock = Number(fallbackBlock);
+            window.logger.warn('Failed to fetch subgraph head block, preserving previous checkpoint', error);
+          }
+        }
 
         // Default scan behavior
         for await (const announcementsBatch of umbra.value.fetchSomeAnnouncements(
@@ -533,11 +636,11 @@ function useScan() {
         await filterUserAnnouncementsAsync(spendingPubKey, viewingPrivKey, announcementsQueue);
         scanStatus.value = 'complete';
 
-        // Save the latest block to localStorage for future scans as the start block
-        setLastFetchedBlock(latestBlock.number);
+        // Save the indexed subgraph head (or a conservative fallback) for future scans as the start block.
+        setLastFetchedBlock(nextStartBlock);
 
-        // Update startBlockLocal with the latest block number
-        startBlockLocal.value = latestBlock.number;
+        // Update startBlockLocal with the next scan start block.
+        startBlockLocal.value = nextStartBlock;
       }
     } catch (e) {
       scanStatus.value = 'waiting'; // reset to the default state because we were unable to fetch announcements

--- a/frontend/src/pages/AccountReceive.vue
+++ b/frontend/src/pages/AccountReceive.vue
@@ -635,9 +635,9 @@ function useScan() {
         await filterUserAnnouncementsAsync(spendingPubKey, viewingPrivKey, announcementsQueue);
         scanStatus.value = 'complete';
 
-        // Update the checkpoint only when the head block is known, capped at the requested end block.
+        // Cap the checkpoint at the RPC head too, since announcement fetching may fall back to RPC logs.
         if (nextStartBlock !== undefined) {
-          const checkpoint = Math.min(nextStartBlock, overrides.endBlock ?? nextStartBlock);
+          const checkpoint = Math.min(nextStartBlock, latestBlock.number, overrides.endBlock ?? nextStartBlock);
           setLastFetchedBlock(checkpoint);
           startBlockLocal.value = checkpoint;
         }

--- a/frontend/src/pages/AccountReceive.vue
+++ b/frontend/src/pages/AccountReceive.vue
@@ -415,33 +415,36 @@ function useScan() {
     const ponderNetwork = getPonderNetworkName(chainId);
 
     if (ponderNetwork) {
-      const ponderResponse = await fetch(subgraphUrl, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({
-          query: `{
-            _meta {
-              status
-            }
-          }`,
-        }),
-      });
+      try {
+        const ponderResponse = await fetch(subgraphUrl, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            query: `{
+              _meta {
+                status
+              }
+            }`,
+          }),
+        });
 
-      if (!ponderResponse.ok) throw new Error(`Subgraph head request failed with status ${ponderResponse.status}`);
+        if (!ponderResponse.ok) throw new Error(`Subgraph head request failed with status ${ponderResponse.status}`);
 
-      const ponderPayload = (await ponderResponse.json()) as {
-        data?: { _meta?: { status?: Record<string, { block?: { number?: number } }> } };
-        errors?: Array<{ message: string }>;
-      };
+        const ponderPayload = (await ponderResponse.json()) as {
+          data?: { _meta?: { status?: Record<string, { block?: { number?: number } }> } };
+          errors?: Array<{ message: string }>;
+        };
 
-      const statusError = ponderPayload.errors?.find((error) => error.message.includes('Cannot query field "status"'));
-      if (!statusError && ponderPayload.errors?.length) {
-        throw new Error(ponderPayload.errors.map((error) => error.message).join('; '));
-      }
+        if (ponderPayload.errors?.length) {
+          throw new Error(ponderPayload.errors.map((error) => error.message).join('; '));
+        }
 
-      const ponderHead = ponderPayload.data?._meta?.status?.[ponderNetwork]?.block?.number;
-      if (typeof ponderHead === 'number' && Number.isFinite(ponderHead)) {
-        return ponderHead;
+        const ponderHead = ponderPayload.data?._meta?.status?.[ponderNetwork]?.block?.number;
+        if (typeof ponderHead === 'number' && Number.isFinite(ponderHead)) {
+          return ponderHead;
+        }
+      } catch {
+        // Legacy endpoints can reject the Ponder query with different HTTP statuses or GraphQL errors.
       }
     }
 

--- a/frontend/src/pages/AccountReceive.vue
+++ b/frontend/src/pages/AccountReceive.vue
@@ -635,10 +635,11 @@ function useScan() {
         await filterUserAnnouncementsAsync(spendingPubKey, viewingPrivKey, announcementsQueue);
         scanStatus.value = 'complete';
 
-        // Update the checkpoint only when the head block is known.
+        // Update the checkpoint only when the head block is known, capped at the requested end block.
         if (nextStartBlock !== undefined) {
-          setLastFetchedBlock(nextStartBlock);
-          startBlockLocal.value = nextStartBlock;
+          const checkpoint = Math.min(nextStartBlock, overrides.endBlock ?? nextStartBlock);
+          setLastFetchedBlock(checkpoint);
+          startBlockLocal.value = checkpoint;
         }
       }
     } catch (e) {

--- a/frontend/src/pages/AccountReceive.vue
+++ b/frontend/src/pages/AccountReceive.vue
@@ -501,7 +501,8 @@ function useScan() {
     window.logger.debug(
       `Scanning for announcements from ${startBlockLocal.value ?? 'undefined'} to ${endBlockLocal.value ?? 'undefined'}`
     );
-    const overrides = { startBlock: startBlockLocal.value, endBlock: endBlockLocal.value };
+    // Cleared number inputs can be empty strings; treat an empty end block as an unrestricted scan.
+    const overrides = { startBlock: startBlockLocal.value, endBlock: endBlockLocal.value || undefined };
 
     // Scan for funds
     const spendingPubKey = chooseKey(spendingKeyPair.value?.publicKeyHex);

--- a/frontend/src/pages/AccountReceive.vue
+++ b/frontend/src/pages/AccountReceive.vue
@@ -571,7 +571,7 @@ function useScan() {
         const latestBlock: Block = await getLastBlock(provider.value!);
         mostRecentBlockNumber.value = latestBlock.number;
         mostRecentBlockTimestamp.value = latestBlock.timestamp;
-        let nextStartBlock = latestBlock.number;
+        let nextStartBlock: number | undefined;
         if (umbra.value.chainConfig.subgraphUrl) {
           try {
             nextStartBlock = await getSubgraphHeadBlockNumber(
@@ -579,11 +579,10 @@ function useScan() {
               umbra.value.chainConfig.subgraphUrl
             );
           } catch (error) {
-            const fallbackBlock =
-              startBlockLocal.value ?? mostRecentAnnouncementBlockNumber.value ?? getRegisteredBlockNumber();
-            if (fallbackBlock) nextStartBlock = Number(fallbackBlock);
             window.logger.warn('Failed to fetch subgraph head block, preserving previous checkpoint', error);
           }
+        } else {
+          nextStartBlock = latestBlock.number;
         }
 
         // Default scan behavior
@@ -636,11 +635,11 @@ function useScan() {
         await filterUserAnnouncementsAsync(spendingPubKey, viewingPrivKey, announcementsQueue);
         scanStatus.value = 'complete';
 
-        // Save the indexed subgraph head (or a conservative fallback) for future scans as the start block.
-        setLastFetchedBlock(nextStartBlock);
-
-        // Update startBlockLocal with the next scan start block.
-        startBlockLocal.value = nextStartBlock;
+        // Update the checkpoint only when the head block is known.
+        if (nextStartBlock !== undefined) {
+          setLastFetchedBlock(nextStartBlock);
+          startBlockLocal.value = nextStartBlock;
+        }
       }
     } catch (e) {
       scanStatus.value = 'waiting'; // reset to the default state because we were unable to fetch announcements


### PR DESCRIPTION
## Summary
This changes the Receive page checkpointing logic so subgraph-backed scans advance to the subgraph head block instead of the RPC latest block.

## Why
On Base and other subgraph-dependent chains, the previous logic stored the provider latest block after a scan. If the subgraph lagged behind the RPC head, a newly indexed announcement could be skipped permanently because future scans would start after the missed block.

## What changed
- fetch the subgraph head block from `_meta`
- support both Ponder `_meta.status` and legacy `_meta.block.number` shapes
- use that head block as the next cached `lastFetchedBlock`
- fall back conservatively to the prior scan checkpoint if the head-block lookup fails
